### PR TITLE
[fix-sparqlroute-tests] Replace thread.sleep with scheduler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import sbt.librarymanagement.InclExclRule
 Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / organization := "se.lu.nateko.cp"
-ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / scalaVersion := "3.3.3"
 
 val commonScalacOptions = Seq(
 	"-encoding", "UTF-8",

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -186,7 +186,7 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with TestDbF
 				val request = req(longRunningQuery, ip, Some(`Cache-Control`(`no-cache`)))
 				route(request)
 				route(request)
-				Thread.sleep(100) // to ensure that the third query gets started last
+				Thread.sleep(500) // to ensure that the third query gets started last
 				val query = s"""select * where { <$uri> ?p ?o } # query 3"""
 				testRoute(query, ip):
 					assertCORS()

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -190,10 +190,10 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with TestDbF
 
 		def delay(delay: FiniteDuration): Future[Unit] =
 			val promise = Promise[Unit]()
-			val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
-			scheduler.schedule(new Runnable {
+			val runnable = new Runnable {
 				def run(): Unit = promise.success(())
-			}, delay.toMillis, TimeUnit.MILLISECONDS)
+			}
+			system.scheduler.scheduleOnce(delay, runnable)
 			promise.future
 
 		it("Too many parallel queries result in timeout responses"):

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -26,18 +26,10 @@ import scala.concurrent.Await
 import scala.concurrent.Future
 
 import concurrent.duration.DurationInt
-import java.util.concurrent.FutureTask
-import java.util.concurrent.RunnableFuture
-import scala.concurrent.ExecutionContext
 import scala.concurrent.Promise
-import scala.util.Success
-import scala.util.Failure
-import java.util.concurrent.ScheduledExecutorService
 import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
-// @DoNotDiscover
+@DoNotDiscover
 class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with TestDbFixture:
 
 	import system.{log}


### PR DESCRIPTION
Fix #243 