### PR TITLE
Improve test logging

### DIFF
--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -3,7 +3,7 @@
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<filter class="se.lu.nateko.cp.meta.HttpApiEtagWarningFilter"/>
 		<encoder>
-			<pattern>[%level] [%logger{0}] \(%X{sourceActorSystem}\) %msg %n</pattern>
+			<pattern>[%level] [%logger{0}] %r ms \(%X{sourceActorSystem}\) %msg %n</pattern>
 		</encoder>
 	</appender>
 

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -1,12 +1,16 @@
 <configuration>
+
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<filter class="se.lu.nateko.cp.meta.HttpApiEtagWarningFilter"/>
 		<encoder>
-			<pattern>[%level] %X{akkaSource} - %msg%n</pattern>
+			<pattern>[%level] [%logger{0}] \(%X{sourceActorSystem}\) %msg %n</pattern>
 		</encoder>
 	</appender>
 
 	<root level="info">
 		<appender-ref ref="STDOUT" />
 	</root>
+
+	<logger name="org.semanticweb.owlapi.rdf.rdfxml.parser.OWLRDFConsumer" level="WARN" />
+
 </configuration>

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<filter class="se.lu.nateko.cp.meta.HttpApiEtagWarningFilter"/>
+		<encoder>
+			<pattern>[%level] %X{akkaSource} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>

--- a/src/main/resources/logback-test.xml
+++ b/src/main/resources/logback-test.xml
@@ -3,7 +3,7 @@
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<filter class="se.lu.nateko.cp.meta.HttpApiEtagWarningFilter"/>
 		<encoder>
-			<pattern>[%level] [%logger{0}] %r ms \(%X{sourceActorSystem}\) %msg %n</pattern>
+			<pattern>[%level] [%r] [%logger{0}] \(%X{sourceActorSystem}\) %msg %n</pattern>
 		</encoder>
 	</appender>
 

--- a/src/main/scala/se/lu/nateko/cp/meta/MetaDb.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/MetaDb.scala
@@ -231,7 +231,7 @@ class MetaDbFactory(using system: ActorSystem, mat: Materializer):
 				new StationLabelingService(instanceServers, onto, fileService, metaVocab, conf, log)
 			}
 
-			val sparqlServer = new Rdf4jSparqlServer(repo, config.sparql, log, scheduler)
+			val sparqlServer = new Rdf4jSparqlServer(repo, config.sparql)
 
 			val db = new MetaDb(instanceServers, instOntos, uploadService, labelingService, fileService, sparqlServer, repo, citer, config)
 			if isFreshInit then sail.makeReadonly("This was a fresh RDF store initialization, running in " +

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationProvider.scala
@@ -44,6 +44,7 @@ import scala.util.Using
 
 import CitationClient.CitationCache
 import CitationClient.DoiCache
+import akka.event.Logging
 
 
 object CitationProvider:
@@ -60,7 +61,7 @@ class CitationProvider(
 	citClientFactory: List[Doi] => CitationClient,
 	conf: CpmetaConfig,
 )(using system: ActorSystem, mat: Materializer):
-	import system.log
+	private val log = Logging.getLogger(system, this)
 	import TriplestoreConnection.*
 	private given envriConfs: EnvriConfigs = conf.core.envriConfigs
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/Rdf4jSparqlServer.scala
@@ -63,7 +63,7 @@ class Rdf4jSparqlServer(
 	private val log = Logging.getLogger(system, this)
 	private val sparqlExe = Executors.newCachedThreadPool() //.newFixedThreadPool(3)
 	private val quoter = new QuotaManager(config, sparqlExe)(Instant.now _)
-	import system.dispatcher
+	private given ExecutionContext = system.dispatcher
 
 	//QuotaManager should be cleaned periodically to forget very old query runs
 	system.scheduler.scheduleWithFixedDelay(1.hour, 1.hour)(() => quoter.cleanup())

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/Rdf4jSparqlServer.scala
@@ -57,12 +57,13 @@ import akka.event.Logging
 
 
 class Rdf4jSparqlServer(
-	repo: Repository, config: SparqlServerConfig)(using ExecutionContext)(using system: ActorSystem) extends SparqlServer:
+	repo: Repository, config: SparqlServerConfig)(using system: ActorSystem) extends SparqlServer:
 	import Rdf4jSparqlServer.*
 
 	private val log = Logging.getLogger(system, this)
 	private val sparqlExe = Executors.newCachedThreadPool() //.newFixedThreadPool(3)
 	private val quoter = new QuotaManager(config, sparqlExe)(Instant.now _)
+	import system.dispatcher
 
 	//QuotaManager should be cleaned periodically to forget very old query runs
 	system.scheduler.scheduleWithFixedDelay(1.hour, 1.hour)(() => quoter.cleanup())

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,7 +1,6 @@
 <configuration>
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-		<filter class="se.lu.nateko.cp.meta.HttpApiEtagWarningFilter"/>
 		<encoder>
 			<pattern>[%level] [%r] [%logger{0}] \(%X{sourceActorSystem}\) %msg %n</pattern>
 		</encoder>

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -26,10 +26,11 @@ import scala.concurrent.Future
 
 import concurrent.duration.DurationInt
 import se.lu.nateko.cp.meta.test.services.sparql.regression.TestDb
+import akka.event.Logging
 
 class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with BeforeAndAfterAll:
 
-	import system.{log}
+	private val log = Logging.getLogger(system, this)
 
 	val db = new TestDb("sparqlRoutingTesting")
 
@@ -42,7 +43,7 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with BeforeA
 
 	val sparqlRoute: Future[Route] =
 		db.repo.map: repo =>
-			val rdf4jServer = Rdf4jSparqlServer(repo, sparqlConfig, log, system.scheduler)
+			val rdf4jServer = Rdf4jSparqlServer(repo, sparqlConfig)
 			given ToResponseMarshaller[SparqlQuery] = rdf4jServer.marshaller
 			given EnvriConfigs = Map(
 				Envri.ICOS -> EnvriConfig(null, null, null, null, new URI("http://test.icos.eu/resources/"), null)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -32,11 +32,13 @@ import se.lu.nateko.cp.meta.utils.async.executeSequentially
 import java.nio.file.Files
 import scala.concurrent.Future
 import se.lu.nateko.cp.meta.services.sparql.magic.CpIndex.IndexData
+import akka.event.Logging
 
 class TestDb(name: String) {
-	import system.{dispatcher, log}
+	import system.dispatcher
 
 	private given system: ActorSystem = ActorSystem(name, akkaConf)
+	private val log = Logging.getLogger(system, this)
 	private val dir = Files.createTempDirectory(name).toAbsolutePath
 	private val metaConf = se.lu.nateko.cp.meta.ConfigLoader.default
 	private val akkaConf =

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -33,11 +33,12 @@ import java.nio.file.Files
 import scala.concurrent.Future
 import se.lu.nateko.cp.meta.services.sparql.magic.CpIndex.IndexData
 import akka.event.Logging
+import scala.concurrent.ExecutionContext
 
 class TestDb(name: String) {
 
 	private given system: ActorSystem = ActorSystem(name, akkaConf)
-	import system.dispatcher
+	private given ExecutionContext = system.dispatcher
 	private val log = Logging.getLogger(system, this)
 	private val dir = Files.createTempDirectory(name).toAbsolutePath
 	private val metaConf = se.lu.nateko.cp.meta.ConfigLoader.default

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -35,9 +35,9 @@ import se.lu.nateko.cp.meta.services.sparql.magic.CpIndex.IndexData
 import akka.event.Logging
 
 class TestDb(name: String) {
-	import system.dispatcher
 
 	private given system: ActorSystem = ActorSystem(name, akkaConf)
+	import system.dispatcher
 	private val log = Logging.getLogger(system, this)
 	private val dir = Files.createTempDirectory(name).toAbsolutePath
 	private val metaConf = se.lu.nateko.cp.meta.ConfigLoader.default


### PR DESCRIPTION
These are minimal changes for making the logging output when running tests more informative. Only code which affects logs during a clean run of test have been edited.
I have added a logging configuration (`logback-test.xml` which gets automatically picked up by logback when testing), and changes in how the logging instances are created. The latter change can be applied across the rest of our codebase for the same results across more modules.

The main change is that loggers are instantiated using `akka.event.Logging.getLogger(ActorSystem, this)` which provides a logger which is decorated by the current class and handled by an actor system. What we currently do in most places is to simply reuse `system.log`, which loses information of where something is logged since the origin will always be the top `ActorSystem`'

Below are examples of how the current output looks, and how it looks with these changes. 

**Old**
```
2025-01-24 14:26:14,303 INFO  [akkaTests-akka.actor.default-dispatcher-6]  - Slf4jLogger started
2025-01-24 14:26:14,304 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-5]  - Slf4jLogger started
2025-01-24 14:26:14,304 INFO  [CachedSourceTests-akka.actor.default-dispatcher-6]  - Slf4jLogger started
2025-01-24 14:26:14,303 INFO  [YourSystem-akka.actor.default-dispatcher-7]  - Slf4jLogger started
2025-01-24 14:26:14,303 INFO  [se-lu-nateko-cp-meta-test-routes-AlternativePathRouteTest-akka.actor.default-dispatcher-6]  - Slf4jLogger started
2025-01-24 14:26:14,304 INFO  [ZipEntryStreamingTests-akka.actor.default-dispatcher-7]  - Slf4jLogger started
2025-01-24 14:26:14,420 WARN  [Cleaner-5]  - Forced closing of unclosed iteration. Set the system property 'org.eclipse.rdf4j.repository.debug' to 'true' to get stack traces.
[WARN] [01/24/2025 14:26:14.764] [pool-48-thread-4] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] ATTENTION: THIS IS A FRESH INIT OF META SERVICE. RESTART ON COMPLETION WITH cpmeta.rdfStorage.recreateAtStartup = false
[INFO] [01/24/2025 14:26:14.779] [pool-48-thread-4] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] LmdbStore instantiated
[INFO] [01/24/2025 14:26:14.793] [pool-48-thread-4] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Initializing LmdbStore SailRepository...
[WARN] [01/24/2025 14:26:14.808] [pool-48-thread-6] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] ATTENTION: THIS IS A FRESH INIT OF META SERVICE. RESTART ON COMPLETION WITH cpmeta.rdfStorage.recreateAtStartup = false
[INFO] [01/24/2025 14:26:14.808] [pool-48-thread-6] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] LmdbStore instantiated
[INFO] [01/24/2025 14:26:14.809] [pool-48-thread-6] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Initializing LmdbStore SailRepository...
2025-01-24 14:26:14,817 INFO  [akkaTests-akka.actor.default-dispatcher-15] CoordinatedShutdown(akka://akkaTests) - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
2025-01-24 14:26:14,817 INFO  [CachedSourceTests-akka.actor.default-dispatcher-7] CoordinatedShutdown(akka://CachedSourceTests) - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
2025-01-24 14:26:14,841 INFO  [ZipEntryStreamingTests-akka.actor.default-dispatcher-8] CoordinatedShutdown(akka://ZipEntryStreamingTests) - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
2025-01-24 14:26:14,956 INFO  [YourSystem-akka.actor.default-dispatcher-15] CoordinatedShutdown(akka://YourSystem) - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[INFO] [01/24/2025 14:26:14.965] [pool-48-thread-4] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] LmdbStore initialized
[INFO] [01/24/2025 14:26:14.965] [pool-48-thread-6] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] LmdbStore initialized[info] MetadataUpdaterTests:
2025-01-24 14:26:14,988 INFO  [se-lu-nateko-cp-meta-test-routes-AlternativePathRouteTest-akka.actor.default-dispatcher-6] CoordinatedShutdown(akka://se-lu-nateko-cp-meta-test-routes-AlternativePathRouteTest) - Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
[INFO] [01/24/2025 14:26:19.324] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] LmdbStore instantiated
[INFO] [01/24/2025 14:26:19.324] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Initializing LmdbStore SailRepository...
[INFO] [01/24/2025 14:26:19.327] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] LmdbStore initialized
[INFO] [01/24/2025 14:26:19.340] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Initializing Carbon Portal index...
[INFO] [01/24/2025 14:26:19.351] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] LmdbStore instantiated
[INFO] [01/24/2025 14:26:19.351] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Initializing LmdbStore SailRepository...
[INFO] [01/24/2025 14:26:19.353] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] LmdbStore initialized
[INFO] [01/24/2025 14:26:19.358] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Initializing Carbon Portal index...
[INFO] [01/24/2025 14:26:19.925] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] SPARQL magic index initialized by 172771 RDF assertions
[INFO] [01/24/2025 14:26:19.928] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Carbon Portal index initialized with info on 7433 data objects
[INFO] [01/24/2025 14:26:19.941] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] SPARQL magic index initialized by 172771 RDF assertions
[INFO] [01/24/2025 14:26:19.943] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Carbon Portal index initialized with info on 7433 data objects
[INFO] [01/24/2025 14:26:20.018] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Starting to add data objects to geo index
[INFO] [01/24/2025 14:26:20.018] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Starting to add data objects to geo index
[INFO] [01/24/2025 14:26:20.462] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Geo index initialized with info on 4575 data objects
[INFO] [01/24/2025 14:26:20.467] [sparqlRegrTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Geo index initialized with info on 4575 data objects
[INFO] [01/24/2025 14:26:20.594] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Switched the triple store to read-only mode. SPARQL index and citations cache dumped to disk
[INFO] [01/24/2025 14:26:20.595] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Switched the triple store to read-only mode. SPARQL index and citations cache dumped to disk
[INFO] [01/24/2025 14:26:20.661] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] LmdbStore instantiated
[INFO] [01/24/2025 14:26:20.661] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] LmdbStore instantiated
[INFO] [01/24/2025 14:26:20.661] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Initializing LmdbStore SailRepository...
[INFO] [01/24/2025 14:26:20.661] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Initializing LmdbStore SailRepository...
[INFO] [01/24/2025 14:26:20.664] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] LmdbStore initialized
[INFO] [01/24/2025 14:26:20.666] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] LmdbStore initialized
[INFO] [01/24/2025 14:26:20.670] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] CpIndex got initialized with non-empty index data to use
[INFO] [01/24/2025 14:26:20.670] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] CpIndex got initialized with non-empty index data to use
[INFO] [01/24/2025 14:26:20.700] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Starting to add data objects to geo index
[INFO] [01/24/2025 14:26:20.700] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Starting to add data objects to geo index
[INFO] [01/24/2025 14:26:20.907] [sparqlRoutingTesting-akka.actor.default-dispatcher-7] [akka.actor.ActorSystemImpl(sparqlRoutingTesting)] Geo index initialized with info on 4575 data objects
[INFO] [01/24/2025 14:26:20.917] [sparqlRegrTesting-akka.actor.default-dispatcher-6] [akka.actor.ActorSystemImpl(sparqlRegrTesting)] Geo index initialized with info on 4575 data objects
[INFO] [01/24/2025 14:26:21.858] [scala-execution-context-global-413] [CoordinatedShutdown(akka://sparqlRegrTesting)] Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
2025-01-24 14:26:26,617 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-6] akka.actor.ActorSystemImpl(se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) - Terminating long-running query 5 from client 127.0.0.1
2025-01-24 14:26:31,647 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-6] akka.actor.ActorSystemImpl(se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) - Terminating long-running query 6 from client 127.0.1.1
2025-01-24 14:26:31,651 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-6] akka.actor.ActorSystemImpl(se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) - Terminating long-running query 7 from client 127.0.1.1
2025-01-24 14:26:36,676 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-32] akka.actor.ActorSystemImpl(se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) - Terminating long-running query 8 from client 127.0.2.1
2025-01-24 14:26:36,736 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-32] akka.actor.ActorSystemImpl(se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) - Terminating long-running query 9 from client 127.0.2.1
2025-01-24 14:26:36,826 INFO  [se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-26] akka.actor.ActorSystemImpl(se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) - Terminating long-running query 10 from client 127.0.2.1
```

**New**
```
[INFO] [Slf4jLogger] () Slf4jLogger started 
[INFO] [Slf4jLogger] () Slf4jLogger started 
[INFO] [Slf4jLogger] () Slf4jLogger started 
[INFO] [Slf4jLogger] () Slf4jLogger started 
[INFO] [Slf4jLogger] () Slf4jLogger started 
[INFO] [Slf4jLogger] () Slf4jLogger started 
[INFO] [CoordinatedShutdown] (CachedSourceTests) Running CoordinatedShutdown with reason [ActorSystemTerminateReason] 
[INFO] [CoordinatedShutdown] (akkaTests) Running CoordinatedShutdown with reason [ActorSystemTerminateReason] 
[INFO] [CoordinatedShutdown] (ZipEntryStreamingTests) Running CoordinatedShutdown with reason [ActorSystemTerminateReason] 
[WARN] [TestDb] (sparqlRegrTesting) ATTENTION: THIS IS A FRESH INIT OF META SERVICE. RESTART ON COMPLETION WITH cpmeta.rdfStorage.recreateAtStartup = false 
[WARN] [TestDb] (sparqlRoutingTesting) ATTENTION: THIS IS A FRESH INIT OF META SERVICE. RESTART ON COMPLETION WITH cpmeta.rdfStorage.recreateAtStartup = false 
[INFO] [TestDb] (sparqlRegrTesting) LmdbStore instantiated 
[INFO] [TestDb] (sparqlRoutingTesting) LmdbStore instantiated 
[INFO] [CitationProvider] (sparqlRegrTesting) Initializing LmdbStore SailRepository... 
[INFO] [CitationProvider] (sparqlRoutingTesting) Initializing LmdbStore SailRepository... 
[INFO] [CoordinatedShutdown] (YourSystem) Running CoordinatedShutdown with reason [ActorSystemTerminateReason] 
[INFO] [CoordinatedShutdown] (se-lu-nateko-cp-meta-test-routes-AlternativePathRouteTest) Running CoordinatedShutdown with reason [ActorSystemTerminateReason] 
[INFO] [CitationProvider] (sparqlRegrTesting) LmdbStore initialized 
[INFO] [CitationProvider] (sparqlRoutingTesting) LmdbStore initialized 
[INFO] [TestDb] (sparqlRoutingTesting) LmdbStore instantiated 
[INFO] [TestDb] (sparqlRegrTesting) LmdbStore instantiated 
[INFO] [CitationProvider] (sparqlRoutingTesting) Initializing LmdbStore SailRepository... 
[INFO] [CitationProvider] (sparqlRegrTesting) Initializing LmdbStore SailRepository... 
[INFO] [CitationProvider] (sparqlRoutingTesting) LmdbStore initialized 
[INFO] [CitationProvider] (sparqlRegrTesting) LmdbStore initialized 
[INFO] [TestDb] (sparqlRoutingTesting) Initializing Carbon Portal index... 
[INFO] [TestDb] (sparqlRegrTesting) Initializing Carbon Portal index... 
[INFO] [TestDb] (sparqlRegrTesting) SPARQL magic index initialized by 172771 RDF assertions 
[INFO] [TestDb] (sparqlRegrTesting) Carbon Portal index initialized with info on 7433 data objects 
[INFO] [TestDb] (sparqlRoutingTesting) SPARQL magic index initialized by 172771 RDF assertions 
[INFO] [TestDb] (sparqlRoutingTesting) Carbon Portal index initialized with info on 7433 data objects 
[INFO] [TestDb] (sparqlRegrTesting) Starting to add data objects to geo index 
[INFO] [TestDb] (sparqlRoutingTesting) Starting to add data objects to geo index 
[INFO] [TestDb] (sparqlRoutingTesting) Geo index initialized with info on 4575 data objects 
[INFO] [TestDb] (sparqlRegrTesting) Geo index initialized with info on 4575 data objects 
[INFO] [TestDb] (sparqlRegrTesting) Switched the triple store to read-only mode. SPARQL index and citations cache dumped to disk 
[INFO] [TestDb] (sparqlRoutingTesting) Switched the triple store to read-only mode. SPARQL index and citations cache dumped to disk 
[INFO] [TestDb] (sparqlRegrTesting) LmdbStore instantiated 
[INFO] [CitationProvider] (sparqlRegrTesting) Initializing LmdbStore SailRepository... 
[INFO] [TestDb] (sparqlRoutingTesting) LmdbStore instantiated 
[INFO] [CitationProvider] (sparqlRoutingTesting) Initializing LmdbStore SailRepository... 
[INFO] [CitationProvider] (sparqlRegrTesting) LmdbStore initialized 
[INFO] [TestDb] (sparqlRegrTesting) CpIndex got initialized with non-empty index data to use 
[INFO] [CitationProvider] (sparqlRoutingTesting) LmdbStore initialized 
[INFO] [TestDb] (sparqlRoutingTesting) CpIndex got initialized with non-empty index data to use 
[INFO] [TestDb] (sparqlRegrTesting) Starting to add data objects to geo index 
[INFO] [TestDb] (sparqlRoutingTesting) Starting to add data objects to geo index 
[INFO] [TestDb] (sparqlRegrTesting) Geo index initialized with info on 4575 data objects 
[INFO] [TestDb] (sparqlRoutingTesting) Geo index initialized with info on 4575 data objects 
[INFO] [CoordinatedShutdown] (sparqlRegrTesting) Running CoordinatedShutdown with reason [ActorSystemTerminateReason] 
[INFO] [Rdf4jSparqlServer] (se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) Terminating long-running query 5 from client 127.0.0.1 
[INFO] [Rdf4jSparqlServer] (se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) Terminating long-running query 7 from client 127.0.1.1 
[INFO] [Rdf4jSparqlServer] (se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) Terminating long-running query 6 from client 127.0.1.1 
[INFO] [Rdf4jSparqlServer] (se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) Terminating long-running query 8 from client 127.0.2.1 
[INFO] [Rdf4jSparqlServer] (se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) Terminating long-running query 9 from client 127.0.2.1 
[INFO] [Rdf4jSparqlServer] (se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests) Terminating long-running query 10 from client 127.0.2.1 
```