### PR TITLE
Use unused allReceps in LifecycleService.sendTestEmail

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/LifecycleService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/LifecycleService.scala
@@ -115,7 +115,7 @@ trait LifecycleService:
 			val subj = "labeling email test"
 			val allReceps = addr.toSeq ++ config.mailing.logBccAddress
 			val body = views.html.CpEmail(subj)(Html("<p>Test successful if you got this</p>"))
-			mailWithLogging(addr.toSeq, subj, body)
+			mailWithLogging(allReceps, subj, body)
 		else
 			log.info("Emailing test requested, but mail sending disabled, so not sending anything")
 


### PR DESCRIPTION
Stemming from this comment: https://github.com/ICOS-Carbon-Portal/meta/pull/281#discussion_r1931715248

This looks like a mistake, where we ignore the value from `config.mailing.logBccAddress`.
Since it's a test email sendout, I guess it hasn't mattered that much, but still looks like a bug.

In order to catch cases like this earlier, I would suggest to add `-Wunused:all` and `-Wvalue-discard` to our build options. That is how I have found these cases, and we currently have many more warnings that may uncover some more bugs like these (and future ones).