### PR TITLE
[Suggestion/Discussion] Improve logback configuration

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,7 +3,7 @@
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<filter class="se.lu.nateko.cp.meta.HttpApiEtagWarningFilter"/>
 		<encoder>
-			<pattern>%date{ISO8601} %-5level [%thread] %X{akkaSource} - %msg%n</pattern>
+			<pattern>[%level] [%date{ISO8601}] %logger{0} \(%X{sourceActorSystem}\) - %msg %n</pattern>
 		</encoder>
 	</appender>
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -2,7 +2,7 @@
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>[%level] [%replace(%r){'(.*)(\d\d\d)$', '$1.$2'}] [%logger{0}] \(%X{sourceActorSystem}\) %msg %n</pattern>
+			<pattern>[%level] [%replace(%r){'(.*)(\d\d\d)$', '$1.$2'}] %logger{0} \(%X{sourceActorSystem}\) - %msg %n</pattern>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
As a followup of https://github.com/ICOS-Carbon-Portal/meta/pull/281, I think we can improve our logback configuration, finding a balance between readability and information content.
My view is that the test and production configurations serve different use-cases and can therefore be a bit different. I prefer log output during test to be terser by default, since the configuration can be manually edited in cases where needed. As a future change, I would like us to have structural logging (JSON, probably) through a secondary logback appender, but that is only relevant if we also have a way to ingest those structured logs.

My first commit here is my suggested configuration, where I have opted to remove `thread`, since I feel the Akka system is more relevant. However, it seems essentially the whole application runs in the `cpmeta` system anyway, so possibly we should change this to only having `thread` and not the actor system (since the name of the system is included in the thread name).
I also opt for `milliseconds-since-start` as the time in the test config, compared to full date in the production config. The reason being that the day, hour and minute (mostly) part of date will always be the same during a test run, and the interesting information is how much time passes between events during tests, rather than actual date. 

**Output examples:**
- Production: `meta [INFO] [2025-01-27 17:06:13,050] CitationProvider (cpmeta) - Initializing LmdbStore SailRepository...`
- Test: `[INFO] [5.482] CitationProvider (sparqlRoutingTesting) - Initializing LmdbStore SailRepository...`