### PR TITLE
Fix sporadic test failures by improving TestDb initialization

### DIFF
--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import akka.pattern.after
 import eu.icoscp.envri.Envri
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
 import se.lu.nateko.cp.meta.SparqlServerConfig
@@ -28,13 +27,11 @@ import concurrent.duration.DurationInt
 import se.lu.nateko.cp.meta.test.services.sparql.regression.TestDb
 import akka.event.Logging
 
-class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with BeforeAndAfterAll:
+class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 
 	private val log = Logging.getLogger(system, this)
 
 	val db = TestDb()
-
-	override protected def afterAll(): Unit = db.cleanup()
 
 	val numberOfParallelQueries = 2
 	private val reqOrigin = "https://example4567.icos-cp.eu"
@@ -44,7 +41,7 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with BeforeA
 	// TODO: Changing this signature to just Route and updating tests accordingly breaks things.
 	//			 Tests can probably be rewritten so that doesn't happen.
 	val sparqlRoute: Future[Route] =
-		Future.successful {
+		Future.apply {
 			val rdf4jServer = Rdf4jSparqlServer(db.repo, sparqlConfig)
 			given ToResponseMarshaller[SparqlQuery] = rdf4jServer.marshaller
 			given EnvriConfigs = Map(

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -32,7 +32,7 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest with BeforeA
 
 	private val log = Logging.getLogger(system, this)
 
-	val db = new TestDb("sparqlRoutingTesting")
+	val db = TestDb()
 
 	override protected def afterAll(): Unit = db.cleanup()
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -41,7 +41,6 @@ class QueryTests extends AsyncFunSpec with BeforeAndAfterAll {
 		describe(descr){
 			
 			given rows: Rows = for (
-				_ <- if(db.repo.isCompleted) db.repo else timedExecution(db.repo, "TestDb init", info);
 				r <- timedExecution(db.runSparql(q), descr, info)
 			) yield transformResult(r)
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -14,10 +14,12 @@ import se.lu.nateko.cp.meta.api.CloseableIterator
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.IterableHasAsScala
+import akka.actor.ActorSystem
 
 class QueryTests extends AsyncFunSpec with BeforeAndAfterAll {
 
-	val db = new TestDb("sparqlRegrTesting")
+	private given system: ActorSystem = ActorSystem("sparqlRegrTesting")
+	val db = new TestDb(system.name)
 
 	override protected def afterAll(): Unit = db.cleanup()
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -14,13 +14,10 @@ import se.lu.nateko.cp.meta.api.CloseableIterator
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.IterableHasAsScala
-import akka.actor.ActorSystem
 
 class QueryTests extends AsyncFunSpec with BeforeAndAfterAll {
 
-	private given system: ActorSystem = ActorSystem("sparqlRegrTesting")
-	val db = new TestDb(system.name)
-
+	val db = TestDb()
 	override protected def afterAll(): Unit = db.cleanup()
 
 	def timedExecution[T](f: Future[T], executedFunction: String, info: Informer)(using ExecutionContext) = {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -51,33 +51,31 @@ class QueryTests extends AsyncFunSpec with BeforeAndAfterAll {
 			}
 
 			it("should return correct sample row") {
-				db.repo.flatMap(repo => {
-					for (r <- rows) yield {
-						val sampleRow = r(sampleIndex).asScala.map(b => b.getName -> b.getValue).toMap
-						val expectations = sampleMaker(repo.getValueFactory)
+				for (r <- rows) yield {
+					val sampleRow = r(sampleIndex).asScala.map(b => b.getName -> b.getValue).toMap
+					val expectations = sampleMaker(db.repo.getValueFactory)
 
-						assert (sampleRow.keySet === expectations.keySet, "variable lists did not match")
+					assert (sampleRow.keySet === expectations.keySet, "variable lists did not match")
 
-						val plainExp: Map[String, Value] = expectations.collect:
-							case (varName, expectation: Value) => varName -> expectation
-						val samplePlainPart = sampleRow.filter:
-							case (varName, _) => plainExp.contains(varName)
+					val plainExp: Map[String, Value] = expectations.collect:
+						case (varName, expectation: Value) => varName -> expectation
+					val samplePlainPart = sampleRow.filter:
+						case (varName, _) => plainExp.contains(varName)
 
-						assert(samplePlainPart === plainExp)
+					assert(samplePlainPart === plainExp)
 
-						expectations.foreach:
-							case (varName, testThunk: Function1[Value, Boolean] @ unchecked) =>
-								val sampleValue = sampleRow(varName)
-								assert(
-									testThunk(sampleValue),
-									s"value $sampleValue for variable $varName was unexpected"
-								)
+					expectations.foreach:
+						case (varName, testThunk: Function1[Value, Boolean] @ unchecked) =>
+							val sampleValue = sampleRow(varName)
+							assert(
+								testThunk(sampleValue),
+								s"value $sampleValue for variable $varName was unexpected"
+							)
 
-							case _ =>
+						case _ =>
 
-						succeed
-					}
-				})
+					succeed
+				}
 			}
 		}
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -5,7 +5,6 @@ import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.query.BindingSet
 import org.scalatest
-import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Informer
 import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
@@ -15,10 +14,9 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.IterableHasAsScala
 
-class QueryTests extends AsyncFunSpec with BeforeAndAfterAll {
+class QueryTests extends AsyncFunSpec {
 
 	val db = TestDb()
-	override protected def afterAll(): Unit = db.cleanup()
 
 	def timedExecution[T](f: Future[T], executedFunction: String, info: Informer)(using ExecutionContext) = {
 		val start = System.currentTimeMillis()

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -64,6 +64,7 @@ class TestDb(name: String)(using system: ActorSystem) {
 			data structure, and initialize the index from it
 		**/
 
+		log.info("Initializing.")
 		val start = System.currentTimeMillis()
 		for
 			() <- ingestTriplestore(dir)
@@ -79,6 +80,7 @@ class TestDb(name: String)(using system: ActorSystem) {
 		Future.apply(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
 
 	def cleanup(): Unit =
+		log.info("Cleaning up!")
 		repo.shutDown()
 		FileUtils.deleteDirectory(dir.toFile)
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -54,7 +54,7 @@ class TestDb {
 	def runSparql(query: String): Future[CloseableIterator[BindingSet]] =
 		TestRepo.runSparql(query)
 
-	def cleanup(): Unit = {
+	override def finalize(): Unit = { 
 		TestRepo.close()
 	}
 }
@@ -69,7 +69,7 @@ private object TestRepo {
 	private given log: LoggingAdapter = Logging.getLogger(system, this)
 
 	def runSparql(query: String): Future[CloseableIterator[BindingSet]] =
-		Future.apply(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
+		Future.successful(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
 
 	private def initRepo(): Future[Repository] = {
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -21,15 +21,12 @@ import se.lu.nateko.cp.meta.{LmdbConfig, RdfStorageConfig}
 import java.nio.file.Files
 import scala.concurrent.{ExecutionContext, Future}
 
-class TestDb(name: String) {
+class TestDb(name: String)(using system: ActorSystem) {
 
-	private given system: ActorSystem = ActorSystem(name, akkaConf)
 	private given ExecutionContext = system.dispatcher
 	private val log = Logging.getLogger(system, this)
 	private val dir = Files.createTempDirectory(name).toAbsolutePath
 	private val metaConf = se.lu.nateko.cp.meta.ConfigLoader.default
-	private val akkaConf =
-		ConfigFactory.defaultReference().withValue("akka.loglevel", ConfigValueFactory.fromAnyRef("INFO"))
 
 	val repo: Future[Repository] =
 		/**

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -3,7 +3,6 @@ package se.lu.nateko.cp.meta.test.services.sparql.regression
 import akka.Done
 import akka.actor.ActorSystem
 import akka.event.Logging
-import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
 import org.apache.commons.io.FileUtils
 import org.eclipse.rdf4j.query.BindingSet
 import org.eclipse.rdf4j.repository.Repository
@@ -129,7 +128,7 @@ private def makeSail(dir: Path)(using ExecutionContext)(using system: ActorSyste
 		Some(indexUpdaterFactory -> geoFactory)
 
 	val citer = new CitationProvider(base, _ => CitationClientDummy, metaConf)
-	CpNotifyingSail(base, idxFactories, citer, log)
+	CpNotifyingSail(base, idxFactories, citer)
 }
 
 object CitationClientDummy extends CitationClient {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -76,7 +76,7 @@ class TestDb(name: String)(using system: ActorSystem) {
 	}
 
 	def runSparql(query: String): Future[CloseableIterator[BindingSet]] =
-		Future.successful(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
+		Future.apply(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
 
 	def cleanup(): Unit =
 		repo.shutDown()

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -69,7 +69,7 @@ private object TestRepo {
 	private given log: LoggingAdapter = Logging.getLogger(system, this)
 
 	def runSparql(query: String): Future[CloseableIterator[BindingSet]] =
-		Future.successful(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
+		Future.apply(new Rdf4jSparqlRunner(repo).evaluateTupleQuery(SparqlQuery(query)))
 
 	private def initRepo(): Future[Repository] = {
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -81,7 +81,6 @@ class TestDb(name: String)(using system: ActorSystem) {
 
 	def cleanup(): Unit =
 		repo.shutDown()
-		system.terminate()
 		FileUtils.deleteDirectory(dir.toFile)
 }
 


### PR DESCRIPTION
Sometimes our test suite fails because of what seems like initialization failure of `TestDb`, which looks like this: https://github.com/ICOS-Carbon-Portal/meta/actions/runs/12991688933/job/36229795601
This PR moves helper functions out of the `TestDb` class, leaving only initialization and cleanup, and exposes `repo` as `Repository` rather than `Future[Repository]` making it clearer where and when initialization happens.

This change results in a longer runtime of `SparqlRouteTests`, roughly from 30s to 50s on my machine, seemingly stemming from the tests relating to long running queries. However, when running tests on `master` with `~test` in sbt this error shows up after a while:
```
[ERROR] [46.751] [AbstractSail] () Closing active connection due to shut down and interrupted the owning thread of the connection Thread[#4397,se-lu-nateko-cp-meta-test-services-sparql-SparqlRouteTests-akka.actor.default-dispatcher-14,5,main] but thread is still alive after 1000 ms! 
[WARN] [46.752] [AbstractSail] () Closing active connection due to shut down; consider setting the org.eclipse.rdf4j.repository.debug system property 
[INFO] [46.758] [CoordinatedShutdown] (sparqlRoutingTesting) Running CoordinatedShutdown with reason [ActorSystemTerminateReason]
```
That behaviour is now gone (for reasons I have not dug into yet).

The rest of the test suite finishes in around 9s on my machine, both on this branch and `master`.