### PR TITLE
Improve parallel query test in SparqlRouteTests

### DIFF
--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -106,7 +106,7 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 
 		it("Syntax error in query"):
 			val query = "selecct * where { ?s ?p ?o }"
-			
+
 			testRoute(query):
 				assert(status === StatusCodes.BadRequest)
 				assertCORS()

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -2,7 +2,6 @@ package se.lu.nateko.cp.meta.test.services.sparql
 
 import se.lu.nateko.cp.meta.test.tags.SlowRoute
 import akka.actor.ActorSystem
-import akka.event.Logging
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.headers.*
 import akka.http.scaladsl.model.headers.CacheDirectives.*

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -204,6 +204,8 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 					res
 				}
 
+				// Launch several requests than the value of maxParallelQueries,
+				// some of which should be rejected.
 				val requests = Seq.range(0, 6).map(launchRequest)
 
 				Future.sequence(requests).map(results =>

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -9,7 +9,6 @@ import akka.http.scaladsl.model.headers.CacheDirectives.*
 import akka.http.scaladsl.model.{HttpHeader, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import akka.pattern.after
 import eu.icoscp.envri.Envri
 import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
@@ -27,8 +26,6 @@ import concurrent.duration.DurationInt
 
 @tags.DbTest
 class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
-
-	private val log = Logging.getLogger(system, this)
 
 	lazy val db = TestDb()
 
@@ -188,14 +185,27 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 			val uri = "https://meta.icos-cp.eu/objects/R5U1rVcbEQbdf9l801lvDUSZ"
 			val ip = "127.0.2.1"
 
+			val start = System.currentTimeMillis()
 			sparqlRoute.flatMap: route =>
-				val request = req(longRunningQuery, ip, Some(`Cache-Control`(`no-cache`)))
-				route(request)
-				route(request)
-				val query = s"""select * where { <$uri> ?p ?o } # query 3"""
-				after(100.millis): // to ensure that the third query gets started last
-					testRoute(query, ip):
-						assertCORS()
-						assert(status == StatusCodes.BadRequest)
+				def launchRequest(id : Int) = {
+					val query = s"""select * where { <$uri> ?p ?o }"""
+					val request = req(query, ip, Some(`Cache-Control`(`no-cache`)))
+					info(s"[${System.currentTimeMillis() - start}] Launching request ${id.toString()}")
+					val res = route(request)
+					res.onComplete(_ => info(s"[${System.currentTimeMillis() - start}] Request ${id.toString()} finished"))
+					res
+				}
+
+				val requests = Seq.range(0, 6).map(launchRequest)
+
+				Future.sequence(requests).map(results =>
+					val statuses = results.map(_.status)
+					info(s"statuses: ${statuses.toString()}")
+					val accepted = statuses.filter(_ == StatusCodes.OK)
+					val rejected = statuses.filter(_ == StatusCodes.BadRequest)
+					assert(accepted.length >= 1)
+					assert(rejected.length >= 1)
+				)
+
 
 end SparqlRouteTests


### PR DESCRIPTION
In the previous implementation of the test, it is not clear that we are getting rejections because of parallel queries, and the test runs for longer than necessary since we are relying on a long running query.
This version instead launches multiple short queries, logs their timestamps (so it is clear they are running in parallel when looking at test output), and verifies that some fail and some succeed.