### PR TITLE
Add test tags: DbTest, SlowRoute

### DIFF
--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -9,6 +9,7 @@ import org.scalatest.Informer
 import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
+import se.lu.nateko.cp.meta.test.DbTest
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -16,7 +17,7 @@ import scala.jdk.CollectionConverters.IterableHasAsScala
 
 class QueryTests extends AsyncFunSpec {
 
-	val db = TestDb()
+	lazy val db = TestDb()
 
 	def timedExecution[T](f: Future[T], executedFunction: String, info: Informer)(using ExecutionContext) = {
 		val start = System.currentTimeMillis()
@@ -39,13 +40,13 @@ class QueryTests extends AsyncFunSpec {
 				r <- timedExecution(db.runSparql(q), descr, info)
 			) yield transformResult(r)
 
-			it(s"should return $expectRows rows") {
+			it(s"should return $expectRows rows", DbTest) {
 				rows map { r => {
 					assert(r.size === expectRows)
 				}}
 			}
 
-			it("should return correct sample row") {
+			it("should return correct sample row", DbTest) {
 				for (r <- rows) yield {
 					val sampleRow = r(sampleIndex).asScala.map(b => b.getName -> b.getValue).toMap
 					val expectations = sampleMaker(db.repo.getValueFactory)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -9,12 +9,12 @@ import org.scalatest.Informer
 import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
-import se.lu.nateko.cp.meta.test.DbTest
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.IterableHasAsScala
 
+@tags.DbTest
 class QueryTests extends AsyncFunSpec {
 
 	lazy val db = TestDb()
@@ -40,13 +40,13 @@ class QueryTests extends AsyncFunSpec {
 				r <- timedExecution(db.runSparql(q), descr, info)
 			) yield transformResult(r)
 
-			it(s"should return $expectRows rows", DbTest) {
+			it(s"should return $expectRows rows") {
 				rows map { r => {
 					assert(r.size === expectRows)
 				}}
 			}
 
-			it("should return correct sample row", DbTest) {
+			it("should return correct sample row") {
 				for (r <- rows) yield {
 					val sampleRow = r(sampleIndex).asScala.map(b => b.getName -> b.getValue).toMap
 					val expectations = sampleMaker(db.repo.getValueFactory)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -59,6 +59,7 @@ class TestDb {
 private object TestRepo {
 	lazy val repo = Await.result(initRepo(), Duration.Inf)
 	private var reference_count = 0
+	private var open = false
 
 	private lazy val dir = Files.createTempDirectory("testdb").toAbsolutePath
 	private given system: ActorSystem = ActorSystem("TestDb")
@@ -91,13 +92,16 @@ private object TestRepo {
 	}
 
 	def checkout() = {
+		log.info("Checkout")
+		open = true
 		reference_count += 1;
 	}
 
 	def close() = {
 		reference_count -= 1;
-		if (reference_count <= 0) {
+		if (open && reference_count <= 0) {
 			log.info("Cleaning up!")
+			open = false
 			repo.shutDown()
 			FileUtils.deleteDirectory(dir.toFile)
 		}

--- a/src/test/scala/se/lu/nateko/cp/meta/test/tags/DbTest.java
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/tags/DbTest.java
@@ -1,0 +1,13 @@
+package tags;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@org.scalatest.TagAnnotation
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface DbTest {
+}

--- a/src/test/scala/se/lu/nateko/cp/meta/test/tags/TagObjects.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/tags/TagObjects.scala
@@ -1,0 +1,5 @@
+package se.lu.nateko.cp.meta.test.tags
+
+import org.scalatest.Tag
+
+object SlowRoute extends Tag("tags.SlowRoute")


### PR DESCRIPTION
This adds two test tags, allowing the exclusion of tests depending on `TestDb` and the slowest route tests.
If the `DbTest` tag is excluded, the `TestDb` will not be initialized, which decreases total test runtime by a lot. On my machine all tests finish in 5 seconds in this case.

Usage (in sbt):
- `testOnly -- -l tags.DbTest`
- `testOnly -- -l tags.SlowRoute`