### PR TITLE
Clear `fileName` of index objects when `hasName` triple is removed

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
@@ -1,6 +1,6 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.model.{IRI, Value, ValueFactory}
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import org.eclipse.rdf4j.sail.Sail
 import org.roaringbitmap.buffer.{BufferFastAggregation, ImmutableRoaringBitmap, MutableRoaringBitmap}
 import org.slf4j.LoggerFactory
@@ -232,12 +232,9 @@ class CpIndex(sail: Sail, geo: Future[GeoIndex], data: IndexData) extends ReadWr
 			sail.accessEagerly:
 				list.forEach:
 					case RdfUpdate(Rdf4jStatement(subj, pred, obj), isAssertion) =>
-						processUpdate(subj, pred, obj, isAssertion)
+						data.processTriple(subj, pred, obj, isAssertion, vocab)
 					case _ => ()
 			list.clear()
-
-	private def processUpdate(subj: IRI, pred: IRI, obj: Value, isAssertion: Boolean)(using GlobConn): Unit =
-		data.processTriple(subj, pred, obj, isAssertion, vocab)
 
 end CpIndex
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -293,16 +293,13 @@ class IndexData(nObjects: Int)(
 	}
 
 	def getObjEntry(hash: Sha256Sum): ObjEntry = {
-		idLookup.get(hash) match {
-			case None =>
-				val canonicalHash = hash.truncate
-				val oe = new ObjEntry(canonicalHash, objs.length, "")
-				objs += oe
-				idLookup += canonicalHash -> oe.idx
-				oe
-			case Some(obj) =>
-				objs.apply(obj)
-		}
+		idLookup.get(hash).fold {
+			val canonicalHash = hash.truncate
+			val oe = new ObjEntry(canonicalHash, objs.length, "")
+			objs += oe
+			idLookup += canonicalHash -> oe.idx
+			oe
+		}(objs.apply)
 	}
 
 	private def handleContinuousPropUpdate(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -93,10 +93,10 @@ class IndexData(nObjects: Int)(
 				}
 
 			case `hasName` =>
-				modForDobj(subj) { oe =>
+				val _ = modForDobj(subj) { oe =>
 					val fName = obj.stringValue
 					if (isAssertion) oe.fName = fName
-					else if (oe.fName == fName) oe.fileName == null
+					else if (oe.fName == fName) { oe.fName = null }
 					handleContinuousPropUpdate(FileName, fName, oe.idx, isAssertion)
 				}
 
@@ -346,9 +346,7 @@ class IndexData(nObjects: Int)(
 			if (entry.prefix == "") entry.prefix = prefix.intern()
 			Some(mod(entry))
 
-		case _ => 
-			log.warn(s"Not a DataObject: ${dobj.toString()}")
-			None
+		case _ => None
 
 	private def addStat(obj: ObjEntry, initOk: MutableRoaringBitmap): Unit = for key <- keyForDobj(obj) do
 		stats.getOrElseUpdate(key, emptyBitmap).add(obj.idx)

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/ObjEntry.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/ObjEntry.scala
@@ -7,7 +7,7 @@ import se.lu.nateko.cp.meta.services.sparql.magic.ObjInfo
 import java.time.Instant
 import scala.compiletime.uninitialized
 
-class ObjEntry(val hash: Sha256Sum, val idx: Int, var prefix: String) extends ObjInfo with Serializable {
+final class ObjEntry(val hash: Sha256Sum, val idx: Int, var prefix: String) extends ObjInfo with Serializable {
 	var spec: IRI = uninitialized
 	var submitter: IRI = uninitialized
 	var station: IRI = uninitialized
@@ -21,7 +21,7 @@ class ObjEntry(val hash: Sha256Sum, val idx: Int, var prefix: String) extends Ob
 	var submissionEnd: Long = Long.MinValue
 	var isNextVersion: Boolean = false
 
-	private def dateTimeFromLong(dt: Long): Option[Instant] =
+	private final def dateTimeFromLong(dt: Long): Option[Instant] =
 		if (dt == Long.MinValue) None
 		else Some(Instant.ofEpochMilli(dt))
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -7,6 +7,7 @@ import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
 import se.lu.nateko.cp.meta.utils.rdf4j.Loading
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.services.CpVocab
 
 class IndexDataTest extends AnyFunSpec {
 	describe("processTriple") {
@@ -16,40 +17,24 @@ class IndexDataTest extends AnyFunSpec {
 			val factory = repo.getValueFactory
 			val vocab = CpmetaVocab(factory)
 
-			val hash: Sha256Sum = Sha256Sum.fromString("AAAAAAAAAAAAAAAAAAAAAAAA").get
-			info(hash.toString())
+			val subject: IRI = factory.createIRI("https://meta.icos-cp.eu/objects/oAzNtfjXddcnG_irI8fJT7W6")
 
-			// server.access:
-			// 	val hash = TriplestoreConnection.getHashsum(subject, vocab.hasSha256sum)
-			// 	info("hash: "+hash.result.get.toString())
-
-
-			val subject = factory.createIRI("test:subject")
-			server.add(factory.createStatement(subject, vocab.hasName, factory.createIRI("test:name")))
-			assert(server.getStatements(Some(subject), None, None).length == 1)
+			// Make sure we insert a DataObject
+			val hash : Sha256Sum =
+				subject match {
+					case CpVocab.DataObject(hash, _prefix) => hash
+				}
 
 			val data = IndexData(100)()
 			server.access {
-				val insert = data.processTriple(_, _, _, true, vocab)
-				// Ignored?
-				insert(subject, vocab.hasName, factory.createIRI("test:name"))
-
-				assert(data.objs.length == 0)
-				val entry = data.getObjEntry(hash)
+				// Insert hasName triple
+				data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), true, vocab)
 				assert(data.objs.length == 1)
-				val entry2 = data.getObjEntry(hash)
-				assert(data.objs.length == 1)
-				assert(entry == entry2)
-
-				info(data.objs.toString())
-
-				// insert(subject, vocab.hasSha256sum, factory.createIRI(hash.toString()))
-				// info(hash.toString())
-
-				// val hash = TriplestoreConnection.getHashsum(subject, vocab.hasSha256sum)
-				// info(entry.fName)
+				assert(data.getObjEntry(hash).fName == "test:name")
+				// Remove it
+				data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), false, vocab)
+				assert(data.getObjEntry(hash).fName == null)
 			}
-
 		}
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -1,23 +1,19 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
 
-import org.eclipse.rdf4j.model.{IRI, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.model.{IRI, Statement, Value}
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.instanceserver.StatementSource
 import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.Loading
 
-// IndexData requires a TriplestoreConnection but in current tests it is not actually used.
-private class DummyTSC extends TriplestoreConnection {
-  override def close(): Unit = ???
-  override def primaryContext: IRI = ???
-  override def readContexts: Seq[IRI] = ???
-  override def factory: ValueFactory = ???
+// IndexData requires a StatementSource but in current tests it is not actually used,
+// hence we can leave things unimplemented.
+private class DummyStatements extends StatementSource {
   override def getStatements(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): CloseableIterator[Statement] = ???
   override def hasStatement(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): Boolean = ???
-  override def withContexts(primary: IRI, read: Seq[IRI]): TriplestoreConnection = ???
 }
 
 class IndexDataTest extends AnyFunSpec {
@@ -36,7 +32,7 @@ class IndexDataTest extends AnyFunSpec {
 				}
 
 			val data = IndexData(100)()
-			given TriplestoreConnection = DummyTSC()
+			given StatementSource = DummyStatements()
 
 			// Insert hasName triple
 			data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), true, vocab)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -1,0 +1,26 @@
+package se.lu.nateko.cp.meta.test.services.sparql.index
+
+import org.eclipse.rdf4j.model.{IRI, Value}
+import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
+import se.lu.nateko.cp.meta.utils.rdf4j.Loading
+
+class IndexDataTest extends AnyFunSpec {
+	describe("processTriple") {
+		it("clears fName of ObjEntry when hasName tuple is deleted") {
+			val repo = Loading.emptyInMemory
+			val server = new Rdf4jInstanceServer(repo)
+			val factory = repo.getValueFactory
+			val vocab = CpmetaVocab(factory)
+			val data = IndexData(100)()
+
+			given TriplestoreConnection = server.getConnection()
+
+			val insert = data.processTriple(_, _, _, true, vocab)
+
+			insert(factory.createIRI("test:subject"), vocab.hasName, factory.createIRI("test:name"))
+		}
+	}
+}

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -4,17 +4,10 @@ import org.eclipse.rdf4j.model.{IRI, Statement, Value}
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.instanceserver.StatementSource
 import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 
-// IndexData requires a StatementSource but in current tests it is not actually used,
-// hence we can leave things unimplemented.
-private class DummyStatements extends StatementSource {
-  override def getStatements(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): CloseableIterator[Statement] = ???
-  override def hasStatement(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): Boolean = ???
-}
 
 class IndexDataTest extends AnyFunSpec {
 	describe("processTriple") {
@@ -25,13 +18,18 @@ class IndexDataTest extends AnyFunSpec {
 			val subject: IRI = factory.createIRI("https://meta.icos-cp.eu/objects/oAzNtfjXddcnG_irI8fJT7W6")
 
 			// Make sure we insert a DataObject
-			val hash: Sha256Sum =
-				subject match {
-					case CpVocab.DataObject(hash, _prefix) => hash
-				}
+			val CpVocab.DataObject(hash, _) = subject : @unchecked
+			// val hash = subject match
+			// 	case CpVocab.DataObject(hash, _) => hash
 
 			val data = IndexData(100)()
-			given StatementSource = DummyStatements()
+
+			// IndexData requires a StatementSource but in current tests it is not actually used,
+			// hence we can leave things unimplemented.
+			given StatementSource with
+				def getStatements(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): CloseableIterator[Statement] = ???
+				def hasStatement(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): Boolean = ???
+
 
 			// Insert hasName triple
 			data.processTriple(subject, vocab.hasName, factory.createLiteral("test name"), true, vocab)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -1,40 +1,50 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
 
-import org.eclipse.rdf4j.model.IRI
+import org.eclipse.rdf4j.model.{IRI, Statement, Value, ValueFactory}
 import org.scalatest.funspec.AnyFunSpec
-import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
-import se.lu.nateko.cp.meta.utils.rdf4j.Loading
+import se.lu.nateko.cp.meta.api.CloseableIterator
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.services.CpVocab
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.utils.rdf4j.Loading
+
+// IndexData requires a TriplestoreConnection but in current tests it is not actually used.
+private class DummyTSC extends TriplestoreConnection {
+  override def close(): Unit = ???
+  override def primaryContext: IRI = ???
+  override def readContexts: Seq[IRI] = ???
+  override def factory: ValueFactory = ???
+  override def getStatements(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): CloseableIterator[Statement] = ???
+  override def hasStatement(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): Boolean = ???
+  override def withContexts(primary: IRI, read: Seq[IRI]): TriplestoreConnection = ???
+}
 
 class IndexDataTest extends AnyFunSpec {
 	describe("processTriple") {
 		it("clears fName of ObjEntry when hasName tuple is deleted") {
 			val repo = Loading.emptyInMemory
-			val server = new Rdf4jInstanceServer(repo)
 			val factory = repo.getValueFactory
 			val vocab = CpmetaVocab(factory)
 
 			val subject: IRI = factory.createIRI("https://meta.icos-cp.eu/objects/oAzNtfjXddcnG_irI8fJT7W6")
 
 			// Make sure we insert a DataObject
-			val hash : Sha256Sum =
+			val hash: Sha256Sum =
 				subject match {
 					case CpVocab.DataObject(hash, _prefix) => hash
 				}
 
 			val data = IndexData(100)()
-			server.access {
-				// Insert hasName triple
-				data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), true, vocab)
-				assert(data.objs.length == 1)
-				assert(data.getObjEntry(hash).fileName == Some("test:name"))
-				// Remove it
-				data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), false, vocab)
-				assert(data.getObjEntry(hash).fileName == None)
-			}
+			given TriplestoreConnection = DummyTSC()
+
+			// Insert hasName triple
+			data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), true, vocab)
+			assert(data.objs.length == 1)
+			assert(data.getObjEntry(hash).fileName == Some("test:name"))
+			// Remove it
+			data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), false, vocab)
+			assert(data.getObjEntry(hash).fileName == None)
 		}
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -18,7 +18,7 @@ private class DummyStatements extends StatementSource {
 
 class IndexDataTest extends AnyFunSpec {
 	describe("processTriple") {
-		it("clears fName of ObjEntry when hasName tuple is deleted") {
+		it("clears fileName of ObjEntry when hasName tuple is deleted") {
 			val repo = Loading.emptyInMemory
 			val factory = repo.getValueFactory
 			val vocab = CpmetaVocab(factory)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -1,13 +1,13 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
 
 import org.eclipse.rdf4j.model.{IRI, Statement, Value}
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.instanceserver.StatementSource
 import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
-import se.lu.nateko.cp.meta.utils.rdf4j.Loading
 
 // IndexData requires a StatementSource but in current tests it is not actually used,
 // hence we can leave things unimplemented.
@@ -19,8 +19,7 @@ private class DummyStatements extends StatementSource {
 class IndexDataTest extends AnyFunSpec {
 	describe("processTriple") {
 		it("clears fileName of ObjEntry when hasName tuple is deleted") {
-			val repo = Loading.emptyInMemory
-			val factory = repo.getValueFactory
+			val factory = SimpleValueFactory.getInstance()
 			val vocab = CpmetaVocab(factory)
 
 			val subject: IRI = factory.createIRI("https://meta.icos-cp.eu/objects/oAzNtfjXddcnG_irI8fJT7W6")
@@ -35,12 +34,12 @@ class IndexDataTest extends AnyFunSpec {
 			given StatementSource = DummyStatements()
 
 			// Insert hasName triple
-			data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), true, vocab)
+			data.processTriple(subject, vocab.hasName, factory.createLiteral("test name"), true, vocab)
 			assert(data.objs.length == 1)
-			assert(data.getObjEntry(hash).fileName == Some("test:name"))
+			assert(data.getObjEntry(hash).fileName === Some("test name"))
 			// Remove it
-			data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), false, vocab)
-			assert(data.getObjEntry(hash).fileName == None)
+			data.processTriple(subject, vocab.hasName, factory.createLiteral("test name"), false, vocab)
+			assert(data.getObjEntry(hash).fileName === None)
 		}
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -14,30 +14,25 @@ class IndexDataTest extends AnyFunSpec {
 		it("clears fileName of ObjEntry when hasName tuple is deleted") {
 			val factory = SimpleValueFactory.getInstance()
 			val vocab = CpmetaVocab(factory)
-
 			val subject: IRI = factory.createIRI("https://meta.icos-cp.eu/objects/oAzNtfjXddcnG_irI8fJT7W6")
-
-			// Make sure we insert a DataObject
 			val CpVocab.DataObject(hash, _) = subject : @unchecked
-			// val hash = subject match
-			// 	case CpVocab.DataObject(hash, _) => hash
-
 			val data = IndexData(100)()
 
-			// IndexData requires a StatementSource but in current tests it is not actually used,
+			// IndexData requires a StatementSource but in this case we never pull any statements,
 			// hence we can leave things unimplemented.
 			given StatementSource with
 				def getStatements(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): CloseableIterator[Statement] = ???
 				def hasStatement(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null): Boolean = ???
 
-
 			// Insert hasName triple
 			data.processTriple(subject, vocab.hasName, factory.createLiteral("test name"), true, vocab)
 			assert(data.objs.length == 1)
 			assert(data.getObjEntry(hash).fileName === Some("test name"))
+
 			// Remove it
 			data.processTriple(subject, vocab.hasName, factory.createLiteral("test name"), false, vocab)
 			assert(data.getObjEntry(hash).fileName === None)
+			assert(data.objs.length == 1)
 		}
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -1,6 +1,6 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
 
-import org.eclipse.rdf4j.model.{IRI, Value}
+import org.eclipse.rdf4j.model.IRI
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
@@ -30,10 +30,10 @@ class IndexDataTest extends AnyFunSpec {
 				// Insert hasName triple
 				data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), true, vocab)
 				assert(data.objs.length == 1)
-				assert(data.getObjEntry(hash).fName == "test:name")
+				assert(data.getObjEntry(hash).fileName == Some("test:name"))
 				// Remove it
 				data.processTriple(subject, vocab.hasName, factory.createIRI("test:name"), false, vocab)
-				assert(data.getObjEntry(hash).fName == null)
+				assert(data.getObjEntry(hash).fileName == None)
 			}
 		}
 	}


### PR DESCRIPTION
This fixes a minor issue which was found when enabling the `-Wvalue-discard` option.
In short, currently if an object has a `hasName` association which is later removed, the value is not actually updated in the in-memory index. This would be corrected upon next service restart when the the IndexData instance is rebuilt (since the bug is only in the index, not the actual triple store).

The fix probably has negligible real-world effects, but I used it as a way to get more familiar with the workings of the `IndexData` code.
In order to reduce the surface area of the IndexData interface, I also added a trait `StatementSource` including the subset of `TripleStoreConnection` relating only to reading existing statements.  