### PR TITLE
Enable -Werror, -Wunused:imports and fix all warnings using scalafix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val commonScalacOptions = Seq(
 	"-unchecked",
 	"-feature",
 	"-deprecation",
+	"-Werror",
 	"-Wunused:imports"
 )
 
@@ -108,7 +109,7 @@ lazy val meta = (project in file("."))
 	.settings(
 		name := "meta",
 		version := "0.11.0",
-		scalacOptions ++= commonScalacOptions,
+		scalacOptions ++= (commonScalacOptions ++ Seq("-Wconf:src=.*(html|xml):s")),
 
 		excludeDependencies ++= Seq(
 			ExclusionRule("com.github.jsonld-java", "jsonld-java"),

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ val commonScalacOptions = Seq(
 	"-encoding", "UTF-8",
 	"-unchecked",
 	"-feature",
-	"-deprecation"
+	"-deprecation",
+	"-Wunused:imports"
 )
 
 lazy val metaCore = (project in file("core"))

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/MetaCoreConfig.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/MetaCoreConfig.scala
@@ -3,7 +3,7 @@ package se.lu.nateko.cp.meta.core
 import java.net.URI
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import spray.json.{JsonFormat, RootJsonFormat}
+import spray.json.RootJsonFormat
 import spray.json.DefaultJsonProtocol.*
 
 

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/algo/DatetimeHierarchicalBitmap.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/algo/DatetimeHierarchicalBitmap.scala
@@ -1,14 +1,12 @@
 package se.lu.nateko.cp.meta.core.algo
 
-import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
-
 /**
  * Factory for HierarchivalBitmap[Long] suitable for representing java.time.Instant keys
  * (converted to milliseconds since epoch). Internal constants for hierarchy-coordinate calculation
  * algorithm are chosen so that the algorithm works correctly only for years from approximately 1420 AD to 2520 AD
 */
 object DatetimeHierarchicalBitmap:
-	import HierarchicalBitmap.*
+	import HierarchicalBitmap.{Coord, Geo}
 
 	val SpilloverThreshold = 513
 

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/crypto/JsonSupport.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/crypto/JsonSupport.scala
@@ -3,13 +3,10 @@ package se.lu.nateko.cp.meta.core.crypto
 import spray.json.*
 import scala.util.Success
 import scala.util.Failure
-import DefaultJsonProtocol.*
 
 object JsonSupport{
 
 	given RootJsonFormat[Sha256Sum] with{
-		import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-
 		def write(hash: Sha256Sum) = JsString(hash.base64Url)
 
 		def read(value: JsValue): Sha256Sum = value match{

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/GeoJson.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/GeoJson.scala
@@ -5,7 +5,6 @@ import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NoStackTrace
-import java.net.URI
 
 object GeoJson {
 

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/Instrument.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/Instrument.scala
@@ -1,6 +1,5 @@
 package se.lu.nateko.cp.meta.core.data
 import java.time.Instant
-import java.net.URI
 
 case class InstrumentDeployment(
 	instrument: UriResource,

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/Station.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/Station.scala
@@ -2,9 +2,6 @@ package se.lu.nateko.cp.meta.core.data
 
 import java.net.URI
 import java.time.LocalDate
-import scala.util.Try
-import spray.json.*
-import se.lu.nateko.cp.meta.core.CommonJsonSupport
 
 case class Station(
 	org: Organization,

--- a/src/main/scala/se/lu/nateko/cp/meta/CpmetaConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/CpmetaConfig.scala
@@ -1,26 +1,16 @@
 package se.lu.nateko.cp.meta
-
-import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigRenderOptions
-import com.typesafe.config.ConfigValueFactory
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.{appConfig, parseAs}
-import se.lu.nateko.cp.cpauth.core.EmailConfig
-import se.lu.nateko.cp.cpauth.core.PublicAuthConfig
-import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.doi.core.DoiEndpointConfig
-import se.lu.nateko.cp.doi.core.DoiMemberConfig
+import se.lu.nateko.cp.cpauth.core.{EmailConfig, PublicAuthConfig}
+import se.lu.nateko.cp.doi.core.{DoiEndpointConfig, DoiMemberConfig}
 import se.lu.nateko.cp.meta.core.CommonJsonSupport.TypeField
-import se.lu.nateko.cp.meta.core.MetaCoreConfig
 import se.lu.nateko.cp.meta.core.data.OptionalOneOrSeq
-import se.lu.nateko.cp.meta.core.toTypedJson
-import se.lu.nateko.cp.meta.persistence.postgres.DbCredentials
-import se.lu.nateko.cp.meta.persistence.postgres.DbServer
+import se.lu.nateko.cp.meta.core.{MetaCoreConfig, toTypedJson}
+import se.lu.nateko.cp.meta.persistence.postgres.{DbCredentials, DbServer}
 import spray.json.*
 
 import java.net.URI
-import java.net.URL
 import java.nio.file.Files
 import java.nio.file.attribute.FileTime
 import scala.collection.mutable.WeakHashMap

--- a/src/main/scala/se/lu/nateko/cp/meta/Json.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/Json.scala
@@ -1,23 +1,20 @@
 package se.lu.nateko.cp.meta
 
-import spray.json.*
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers.liftMarshaller
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model.{HttpEntity, HttpRequest}
+import akka.http.scaladsl.unmarshalling.{FromRequestUnmarshaller, Unmarshaller}
 import se.lu.nateko.cp.cpauth.core.UserId
+import se.lu.nateko.cp.doi.*
 import se.lu.nateko.cp.meta.core.CommonJsonSupport
 import se.lu.nateko.cp.meta.core.crypto.JsonSupport.given
-import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.doi.*
-import scala.util.Failure
-import scala.util.Success
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.marshalling.PredefinedToResponseMarshallers.liftMarshaller
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.marshalling.ToResponseMarshallable
-import akka.http.scaladsl.unmarshalling.FromRequestUnmarshaller
-import akka.http.scaladsl.unmarshalling.Unmarshaller
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpEntity
 import se.lu.nateko.cp.meta.core.data.GeoFeature
+import se.lu.nateko.cp.meta.core.data.JsonSupport.given
+import spray.json.*
+
 import java.net.URI
+import scala.util.{Failure, Success}
 
 trait CpmetaJsonProtocol extends CommonJsonSupport{
 	import DefaultJsonProtocol.*

--- a/src/main/scala/se/lu/nateko/cp/meta/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/Main.scala
@@ -1,21 +1,19 @@
 package se.lu.nateko.cp.meta
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.stream.Materializer
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.appConfig
 import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import se.lu.nateko.cp.meta.metaflow.MetaFlow
 import se.lu.nateko.cp.meta.routes.MainRoute
-import se.lu.nateko.cp.meta.services.citation.CitationClient.readCitCache
-import se.lu.nateko.cp.meta.services.citation.CitationClient.readDoiCache
-import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
+import se.lu.nateko.cp.meta.services.citation.CitationClient.{readCitCache, readDoiCache}
 import se.lu.nateko.cp.meta.services.sparql.magic.IndexHandler
-import scala.concurrent.Await
-import scala.concurrent.Future
+import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
+
 import scala.concurrent.duration.DurationInt
-import akka.event.Logging
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 object Main extends App with CpmetaJsonProtocol{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/MetaDb.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/MetaDb.scala
@@ -2,60 +2,37 @@ package se.lu.nateko.cp.meta
 
 import akka.Done
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.stream.Materializer
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.repository.sail.SailRepository
 import org.semanticweb.owlapi.apibinding.OWLManager
-import se.lu.nateko.cp.meta.api.RdfLens
-import se.lu.nateko.cp.meta.api.RdfLenses
-import se.lu.nateko.cp.meta.api.SparqlServer
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.flattenToSeq
-import se.lu.nateko.cp.meta.ingestion.BnodeStabilizers
-import se.lu.nateko.cp.meta.ingestion.Extractor
-import se.lu.nateko.cp.meta.ingestion.Ingester
-import se.lu.nateko.cp.meta.ingestion.Ingestion
-import se.lu.nateko.cp.meta.ingestion.StatementProvider
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.LoggingInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.instanceserver.WriteNotifyingInstanceServer
-import se.lu.nateko.cp.meta.onto.InstOnto
-import se.lu.nateko.cp.meta.onto.Onto
+import se.lu.nateko.cp.meta.api.{RdfLens, RdfLenses, SparqlServer}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, flattenToSeq}
+import se.lu.nateko.cp.meta.ingestion.{BnodeStabilizers, Extractor, Ingester, Ingestion, StatementProvider}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, LoggingInstanceServer, Rdf4jInstanceServer, TriplestoreConnection, WriteNotifyingInstanceServer}
+import se.lu.nateko.cp.meta.onto.{InstOnto, Onto}
 import se.lu.nateko.cp.meta.persistence.RdfUpdateLogIngester
 import se.lu.nateko.cp.meta.persistence.postgres.PostgresRdfLog
-import se.lu.nateko.cp.meta.services.FileStorageService
-import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
-import se.lu.nateko.cp.meta.services.ServiceException
-import se.lu.nateko.cp.meta.services.citation.CitationClient.CitationCache
-import se.lu.nateko.cp.meta.services.citation.CitationClient.DoiCache
+import se.lu.nateko.cp.meta.services.citation.CitationClient.{CitationCache, DoiCache}
 import se.lu.nateko.cp.meta.services.citation.CitationProvider
 import se.lu.nateko.cp.meta.services.labeling.StationLabelingService
-import se.lu.nateko.cp.meta.services.linkeddata.Rdf4jUriSerializer
-import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
+import se.lu.nateko.cp.meta.services.linkeddata.{Rdf4jUriSerializer, UriSerializer}
 import se.lu.nateko.cp.meta.services.sparql.Rdf4jSparqlServer
 import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
-import se.lu.nateko.cp.meta.services.sparql.magic.CpNotifyingSail
-import se.lu.nateko.cp.meta.services.sparql.magic.GeoIndexProvider
-import se.lu.nateko.cp.meta.services.sparql.magic.IndexHandler
-import se.lu.nateko.cp.meta.services.sparql.magic.StorageSail
-import se.lu.nateko.cp.meta.services.upload.DataObjectInstanceServers
-import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
-import se.lu.nateko.cp.meta.services.upload.UploadService
+import se.lu.nateko.cp.meta.services.sparql.magic.{CpNotifyingSail, GeoIndexProvider, IndexHandler, StorageSail}
 import se.lu.nateko.cp.meta.services.upload.etc.EtcUploadTransformer
+import se.lu.nateko.cp.meta.services.upload.{DataObjectInstanceServers, StaticObjectReader, UploadService}
+import se.lu.nateko.cp.meta.services.{FileStorageService, Rdf4jSparqlRunner, ServiceException}
 import se.lu.nateko.cp.meta.utils.async.ok
 import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
 
 import java.net.URI
 import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.{Success, Failure}
-import akka.event.Logging
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 
 class MetaDb (

--- a/src/main/scala/se/lu/nateko/cp/meta/UploadDtos.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/UploadDtos.scala
@@ -1,12 +1,11 @@
 package se.lu.nateko.cp.meta
 
-import java.net.URI
-import java.time.Instant
-
+import se.lu.nateko.cp.doi.*
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.doi.*
-import scala.util.Try
+
+import java.net.URI
+import java.time.Instant
 
 sealed trait UploadDto{
 	def submitterId: String

--- a/src/main/scala/se/lu/nateko/cp/meta/api/CustomVocab.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/api/CustomVocab.scala
@@ -1,17 +1,13 @@
 package se.lu.nateko.cp.meta.api
 
-import java.net.URI
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.model.{IRI, Literal, ValueFactory}
+
+import java.net.URI
+import java.time.{Instant, LocalDate, LocalDateTime}
 
 trait CustomVocab {
-	import CustomVocab.urlEncode
+	
 	def factory: ValueFactory
 
 	protected class BaseUriProvider(val baseUri: String)

--- a/src/main/scala/se/lu/nateko/cp/meta/api/HandleNetClient.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/api/HandleNetClient.scala
@@ -2,20 +2,13 @@ package se.lu.nateko.cp.meta.api
 
 import akka.Done
 import akka.actor.ActorSystem
-import akka.http.scaladsl.ConnectionContext
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.HttpMethods
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.RequestEntity
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, RequestEntity, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.stream.Materializer
-import com.typesafe.sslconfig.akka.AkkaSSLConfig
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.HandleNetClientConfig
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
@@ -24,20 +17,12 @@ import se.lu.nateko.cp.meta.utils.async.*
 
 import java.io.FileInputStream
 import java.net.URI
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.security.KeyFactory
-import java.security.KeyStore
-import java.security.SecureRandom
+import java.nio.file.{Files, Path, Paths}
 import java.security.cert.CertificateFactory
-import java.security.interfaces.RSAPrivateKey
-import java.security.interfaces.RSAPublicKey
-import java.security.spec.PKCS8EncodedKeySpec
-import java.security.spec.X509EncodedKeySpec
-import javax.net.ssl.KeyManagerFactory
-import javax.net.ssl.SSLContext
-import javax.net.ssl.TrustManagerFactory
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
+import java.security.{KeyFactory, KeyStore, SecureRandom}
+import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 

--- a/src/main/scala/se/lu/nateko/cp/meta/api/OrganizationExtra.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/api/OrganizationExtra.scala
@@ -1,10 +1,5 @@
 package se.lu.nateko.cp.meta.api
-
-import se.lu.nateko.cp.meta.core.data.FeatureCollection
-import se.lu.nateko.cp.meta.core.data.GeoFeature
 import se.lu.nateko.cp.meta.core.data.Person
-import se.lu.nateko.cp.meta.core.data.Position
-import se.lu.nateko.cp.meta.core.data.Station
 import se.lu.nateko.cp.meta.metaflow.Role
 import se.lu.nateko.cp.meta.services.citation.AttributionProvider
 import spray.json.*

--- a/src/main/scala/se/lu/nateko/cp/meta/api/RdfLenses.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/api/RdfLenses.scala
@@ -2,6 +2,7 @@ package se.lu.nateko.cp.meta.api
 
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.ValueFactory
+import se.lu.nateko.cp.meta.MetaFlowConfig
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.Validated.getOrElseV
@@ -10,7 +11,6 @@ import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
 import java.net.URI
 
 import RdfLens.*
-import se.lu.nateko.cp.meta.MetaFlowConfig
 
 
 type RdfLens[C <: TriplestoreConnection] = TriplestoreConnection ?=> C

--- a/src/main/scala/se/lu/nateko/cp/meta/api/StatisticsClient.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/api/StatisticsClient.scala
@@ -1,26 +1,24 @@
 package se.lu.nateko.cp.meta.api
 
-import java.net.URI
-import scala.concurrent.{ ExecutionContextExecutor, Future }
-import scala.concurrent.duration.DurationInt
-
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
-import akka.http.scaladsl.model.{ HttpRequest, StatusCodes, Uri }
 import akka.http.scaladsl.model.headers.Host
-import akka.http.scaladsl.unmarshalling.{Unmarshal, FromEntityUnmarshaller}
+import akka.http.scaladsl.model.{ HttpRequest, StatusCodes, Uri }
+import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshal}
 import akka.stream.Materializer
+import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.StatsClientConfig
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, StaticObject}
 import se.lu.nateko.cp.meta.services.MetadataException
-import spray.json.DefaultJsonProtocol
-import se.lu.nateko.cp.meta.core.data.StaticObject
-import akka.http.scaladsl.settings.ConnectionPoolSettings
-import spray.json.RootJsonFormat
-import eu.icoscp.envri.Envri
-import akka.event.Logging
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+
+import java.net.URI
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ ExecutionContextExecutor, Future }
 
 
 object StatisticsClient extends DefaultJsonProtocol {

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/BnodeStabilizers.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/BnodeStabilizers.scala
@@ -1,11 +1,9 @@
 package se.lu.nateko.cp.meta.ingestion
 
-import scala.collection.mutable
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.BNode
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.model.{BNode, IRI, Statement, ValueFactory}
 import se.lu.nateko.cp.meta.utils.rdf4j.createIRI
+
+import scala.collection.mutable
 
 class BnodeStabilizers:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/ExtraStationsIngester.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/ExtraStationsIngester.scala
@@ -1,22 +1,15 @@
 package se.lu.nateko.cp.meta.ingestion
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.io.Source
-
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.ValueFactory
-
-import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.utils.rdf4j.*
-import se.lu.nateko.cp.meta.api.CloseableIterator
 import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, Statement, Value, ValueFactory}
+import se.lu.nateko.cp.meta.api.{CloseableIterator, UriId}
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.utils.rdf4j.*
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.io.Source
 
 class ExtraStationsIngester(extraStationsPath: String)(using ExecutionContext, EnvriConfigs) extends Ingester{
 	import IcosStationsIngester.*

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/Ingestion.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/Ingestion.scala
@@ -1,25 +1,19 @@
 package se.lu.nateko.cp.meta.ingestion
 
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.Statement
-import se.lu.nateko.cp.meta.utils.rdf4j.Loading
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import org.eclipse.rdf4j.repository.Repository
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import java.net.URI
-
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import scala.util.Using
-import se.lu.nateko.cp.meta.api.CloseableIterator
-import se.lu.nateko.cp.meta.ingestion.Ingestion.Statements
-import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement
 import org.eclipse.rdf4j.model.vocabulary.LOCN
-import org.eclipse.rdf4j.model.Literal
+import org.eclipse.rdf4j.model.{Statement, ValueFactory}
+import org.eclipse.rdf4j.repository.Repository
+import se.lu.nateko.cp.meta.api.CloseableIterator
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.ingestion.Ingestion.Statements
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, Rdf4jInstanceServer, RdfUpdate}
+import se.lu.nateko.cp.meta.utils.rdf4j.Loading
+
+import java.net.URI
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Using
 
 sealed trait StatementProvider{
 	def isAppendOnly: Boolean = false

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/LocalSparqlConstructExtractor.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/LocalSparqlConstructExtractor.scala
@@ -5,7 +5,6 @@ import org.eclipse.rdf4j.repository.Repository
 import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlQuery}
 import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
 
-import java.nio.file.{Files, Paths}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/LocalSparqlConstructExtractor.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/LocalSparqlConstructExtractor.scala
@@ -1,16 +1,13 @@
 package se.lu.nateko.cp.meta.ingestion
 
-import java.nio.file.{Files, Paths}
-
-import org.eclipse.rdf4j.repository.Repository
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.io.Source
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
-import se.lu.nateko.cp.meta.api.CloseableIterator
 import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.repository.Repository
+import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlQuery}
+import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
+
+import java.nio.file.{Files, Paths}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.io.Source
 
 class LocalSparqlConstructExtractor(queryRes: String, extras: String*)(using ExecutionContext) extends Extractor{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/PeopleAndOrgsIngester.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/PeopleAndOrgsIngester.scala
@@ -1,23 +1,17 @@
 package se.lu.nateko.cp.meta.ingestion
 
-import scala.io.Source
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import se.lu.nateko.cp.meta.api.UriId
+import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import org.eclipse.rdf4j.model.{IRI, Value, ValueFactory}
+import se.lu.nateko.cp.meta.api.{CloseableIterator, UriId}
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import se.lu.nateko.cp.meta.metaflow.Researcher
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import scala.concurrent.Future
-import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import scala.concurrent.{ExecutionContext, Future}
+import scala.io.Source
 import scala.util.Using
-import se.lu.nateko.cp.meta.api.CloseableIterator
-import scala.concurrent.ExecutionContext
 
 class PeopleAndOrgsIngester(pathToTextRes: String)(using EnvriConfigs, ExecutionContext) extends Ingester{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/RdfXmlFileIngester.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/RdfXmlFileIngester.scala
@@ -1,10 +1,10 @@
 package se.lu.nateko.cp.meta.ingestion
 
+import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.rio.RDFFormat
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import org.eclipse.rdf4j.model.ValueFactory
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
+
+import scala.concurrent.{ExecutionContext, Future}
 
 
 //TODO Consider rewriting using a parser only, without loading all statements into memory

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/RemoteSparqlConstructIngester.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/RemoteSparqlConstructIngester.scala
@@ -1,27 +1,18 @@
 package se.lu.nateko.cp.meta.ingestion
 
-import java.net.URI
-
-import scala.concurrent.Future
-
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector
-import org.eclipse.rdf4j.rio.turtle.TurtleParser
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpMethods
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.MediaTypes
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers
-import akka.stream.scaladsl.StreamConverters
-import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, MediaTypes, StatusCodes, headers}
 import akka.stream.Materializer
+import akka.stream.scaladsl.StreamConverters
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
+import org.eclipse.rdf4j.rio.helpers.ContextStatementCollector
+import org.eclipse.rdf4j.rio.turtle.TurtleParser
 import se.lu.nateko.cp.meta.api.CloseableIterator
-import scala.concurrent.ExecutionContext
+import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
+
+import java.net.URI
+import scala.concurrent.{ExecutionContext, Future}
 
 class RemoteRdfGraphIngester(
 	endpoint: URI, rdfGraph: URI

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/BadmEntry.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/BadmEntry.scala
@@ -1,12 +1,10 @@
 package se.lu.nateko.cp.meta.ingestion.badm
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-
 import se.lu.nateko.cp.meta.core.etcupload.StationId
-import java.text.NumberFormat
+
+import java.text.{NumberFormat, ParseException}
+import java.time.{LocalDate, LocalDateTime}
 import java.util.Locale
-import java.text.ParseException
 
 sealed trait BadmDate
 case class BadmYear(year: Int) extends BadmDate

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/EtcEntriesFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/EtcEntriesFetcher.scala
@@ -1,22 +1,15 @@
 package se.lu.nateko.cp.meta.ingestion.badm
 
-import scala.concurrent.Future
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.HttpMethods
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.RequestEntity
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, HttpResponse, RequestEntity, StatusCodes, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import spray.json.JsObject
-import spray.json.JsValue
-import scala.concurrent.ExecutionContext
+import spray.json.{JsObject, JsValue}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 object EtcEntriesFetcher {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/IcosBadmFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/IcosBadmFetcher.scala
@@ -1,10 +1,11 @@
 package se.lu.nateko.cp.meta.ingestion.badm
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
-import scala.concurrent.Future
-import spray.json.JsObject
 import akka.http.scaladsl.model.Uri
+import akka.stream.Materializer
+import spray.json.JsObject
+
+import scala.concurrent.Future
 
 class IcosBadmFetcher(implicit system: ActorSystem, m: Materializer){
 	val serviceUrl = "http://www.europe-fluxdata.eu/metadata.aspx/getIcosMetadata"

--- a/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/Parser.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/ingestion/badm/Parser.scala
@@ -1,22 +1,15 @@
 package se.lu.nateko.cp.meta.ingestion.badm
 
+import com.opencsv.{CSVParserBuilder, CSVReaderBuilder}
+import se.lu.nateko.cp.meta.core.etcupload.StationId
+import spray.json.{JsArray, JsNumber, JsObject, JsString, JsValue}
+
+import java.io.StringReader
 import java.text.ParseException
-import java.time.LocalDate
+import java.time.{LocalDate, LocalDateTime}
+import scala.util.control.NoStackTrace
 
 import BadmConsts.*
-import com.opencsv.CSVParserBuilder
-import com.opencsv.CSVReaderBuilder
-
-import spray.json.JsArray
-import spray.json.JsNumber
-import spray.json.JsObject
-import spray.json.JsString
-import java.io.StringReader
-import java.time.LocalDateTime
-
-import se.lu.nateko.cp.meta.core.etcupload.StationId
-import spray.json.JsValue
-import scala.util.control.NoStackTrace
 
 object Parser {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/InstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/InstanceServer.scala
@@ -2,7 +2,6 @@ package se.lu.nateko.cp.meta.instanceserver
 
 import org.eclipse.rdf4j.model.*
 import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS, XSD}
-import se.lu.nateko.cp.meta.api.CloseableIterator.empty
 import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlRunner}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.UriResource
@@ -88,7 +87,7 @@ trait TriplestoreConnection extends AutoCloseable:
 
 
 object TriplestoreConnection:
-	import Validated.CardinalityExpectation.{AtLeastOne, AtMostOne, ExactlyOne}
+	import Validated.CardinalityExpectation.{AtMostOne, ExactlyOne}
 	type TSC = TriplestoreConnection
 
 	def getStatements(subject: IRI | Null, predicate: IRI | Null, obj: Value | Null)(using conn: TSC): CloseableIterator[Statement] =

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/InstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/InstanceServer.scala
@@ -1,25 +1,18 @@
 package se.lu.nateko.cp.meta.instanceserver
 
 import org.eclipse.rdf4j.model.*
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import se.lu.nateko.cp.meta.api.CloseableIterator
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS, XSD}
 import se.lu.nateko.cp.meta.api.CloseableIterator.empty
-import se.lu.nateko.cp.meta.api.SparqlRunner
+import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlRunner}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.UriResource
 import se.lu.nateko.cp.meta.services.upload.MetadataUpdater
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.Validated.CardinalityExpectation
-import se.lu.nateko.cp.meta.utils.Validated.validateSize
-import se.lu.nateko.cp.meta.utils.parseInstant
-import se.lu.nateko.cp.meta.utils.rdf4j.===
-import se.lu.nateko.cp.meta.utils.rdf4j.toJava
+import se.lu.nateko.cp.meta.utils.Validated.{CardinalityExpectation, validateSize}
+import se.lu.nateko.cp.meta.utils.rdf4j.{===, toJava}
+import se.lu.nateko.cp.meta.utils.{Validated, parseInstant}
 
 import java.net.URI as JavaUri
-import java.time.Instant
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 import scala.util.Try
 
 trait InstanceServer extends AutoCloseable:

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/LoggingInstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/LoggingInstanceServer.scala
@@ -1,6 +1,6 @@
 package se.lu.nateko.cp.meta.instanceserver
 
-import org.eclipse.rdf4j.model.{IRI, Statement, Value}
+import org.eclipse.rdf4j.model.{IRI, Value}
 import se.lu.nateko.cp.meta.persistence.RdfUpdateLog
 
 import scala.util.Try

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/LoggingInstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/LoggingInstanceServer.scala
@@ -1,8 +1,6 @@
 package se.lu.nateko.cp.meta.instanceserver
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
+import org.eclipse.rdf4j.model.{IRI, Statement, Value}
 import se.lu.nateko.cp.meta.persistence.RdfUpdateLog
 
 import scala.util.Try

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/Rdf4jInstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/Rdf4jInstanceServer.scala
@@ -1,22 +1,15 @@
 package se.lu.nateko.cp.meta.instanceserver
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.query.BindingSet
-import org.eclipse.rdf4j.query.QueryLanguage
-import org.eclipse.rdf4j.repository.Repository
-import org.eclipse.rdf4j.repository.RepositoryConnection
-import se.lu.nateko.cp.meta.api.CloseableIterator
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
+import org.eclipse.rdf4j.model.{IRI, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.query.{BindingSet, QueryLanguage}
+import org.eclipse.rdf4j.repository.{Repository, RepositoryConnection}
+import org.eclipse.rdf4j.sail.SailConnection
+import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlQuery, SparqlRunner}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.util.UUID
 import scala.util.Try
-import org.eclipse.rdf4j.sail.SailConnection
 
 class Rdf4jInstanceServer(repo: Repository, val readContexts: Seq[IRI], val writeContext: IRI) extends InstanceServer:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/Rdf4jInstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/Rdf4jInstanceServer.scala
@@ -5,7 +5,6 @@ import org.eclipse.rdf4j.query.{BindingSet, QueryLanguage}
 import org.eclipse.rdf4j.repository.{Repository, RepositoryConnection}
 import org.eclipse.rdf4j.sail.SailConnection
 import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlQuery, SparqlRunner}
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.util.UUID

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/WriteNotifyingInstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/WriteNotifyingInstanceServer.scala
@@ -1,8 +1,6 @@
 package se.lu.nateko.cp.meta.instanceserver
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
+import org.eclipse.rdf4j.model.{IRI, Statement, Value}
 
 import scala.util.Try
 

--- a/src/main/scala/se/lu/nateko/cp/meta/instanceserver/WriteNotifyingInstanceServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/instanceserver/WriteNotifyingInstanceServer.scala
@@ -1,6 +1,6 @@
 package se.lu.nateko.cp.meta.instanceserver
 
-import org.eclipse.rdf4j.model.{IRI, Statement, Value}
+import org.eclipse.rdf4j.model.{IRI, Value}
 
 import scala.util.Try
 

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/MetaFlow.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/MetaFlow.scala
@@ -1,19 +1,14 @@
 package se.lu.nateko.cp.meta.metaflow
 
 import akka.actor.ActorSystem
-import akka.stream.IOResult
-import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
+import akka.stream.{IOResult, Materializer}
 import akka.util.ByteString
 import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.meta.CitiesMetaFlowConfig
-import se.lu.nateko.cp.meta.CpmetaConfig
-import se.lu.nateko.cp.meta.IcosMetaFlowConfig
-import se.lu.nateko.cp.meta.MetaDb
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.flattenToSeq
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, flattenToSeq}
 import se.lu.nateko.cp.meta.metaflow.cities.CitiesMetaFlow
 import se.lu.nateko.cp.meta.metaflow.icos.IcosMetaFlow
+import se.lu.nateko.cp.meta.{CitiesMetaFlowConfig, CpmetaConfig, IcosMetaFlowConfig, MetaDb}
 
 import java.nio.file.Path
 import scala.concurrent.Future

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfDiffCalc.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfDiffCalc.scala
@@ -1,15 +1,9 @@
 package se.lu.nateko.cp.meta.metaflow
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Resource
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
 import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.metaflow.RdfDiffBuilder.Assertion
-import se.lu.nateko.cp.meta.metaflow.RdfDiffBuilder.Retraction
-import se.lu.nateko.cp.meta.metaflow.RdfDiffBuilder.WeakRetraction
 import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
+import se.lu.nateko.cp.meta.metaflow.RdfDiffBuilder.{Assertion, Retraction, WeakRetraction}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.===
 

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
@@ -3,7 +3,20 @@ package se.lu.nateko.cp.meta.metaflow
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS, XSD}
 import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
-import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment as _, *}
+import se.lu.nateko.cp.meta.core.data.{
+	InstrumentDeployment as _,
+	GeoFeature,
+	UriResource,
+	StationSpecifics,
+	EtcStationSpecifics,
+	AtcStationSpecifics,
+	IcosStationSpecifics,
+	IcosCitiesStationSpecifics,
+	SitesStationSpecifics,
+	NoStationSpecifics,
+	Position,
+	Organization
+}
 import se.lu.nateko.cp.meta.services.upload.StatementsProducer
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
@@ -3,13 +3,10 @@ package se.lu.nateko.cp.meta.metaflow
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS, XSD}
 import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
-import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment as _, *}
 import se.lu.nateko.cp.meta.services.upload.StatementsProducer
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-
-import java.time.Instant
 
 class RdfMaker(vocab: CpVocab, val meta: CpmetaVocab)(using Envri) {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
@@ -1,19 +1,12 @@
 package se.lu.nateko.cp.meta.metaflow
 
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Resource
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS, XSD}
+import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
 import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment as _, *}
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.upload.StatementsProducer
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.time.Instant

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfReader.scala
@@ -1,14 +1,14 @@
 package se.lu.nateko.cp.meta.metaflow
 
 import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
-import org.eclipse.rdf4j.model.{IRI, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.model.{IRI, Statement, ValueFactory}
 import se.lu.nateko.cp.meta.api.RdfLens.{CpLens, DocConn, DocLens, MetaConn, MetaLens}
 import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, Funder, Orcid, Organization, Person, Position}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, Funder}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
 import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate}
+import se.lu.nateko.cp.meta.services.MetadataException
 import se.lu.nateko.cp.meta.services.upload.DobjMetaReader
-import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.Validated.{CardinalityExpectation, validateSize}
 import se.lu.nateko.cp.meta.utils.rdf4j.toRdf

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfReader.scala
@@ -1,29 +1,17 @@
 package se.lu.nateko.cp.meta.metaflow
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import org.eclipse.rdf4j.model.{IRI, Statement, Value, ValueFactory}
+import se.lu.nateko.cp.meta.api.RdfLens.{CpLens, DocConn, DocLens, MetaConn, MetaLens}
 import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.api.RdfLens.{MetaConn, DocConn, MetaLens, DocLens, CpLens}
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.Funder
-import se.lu.nateko.cp.meta.core.data.Orcid
-import se.lu.nateko.cp.meta.core.data.Organization
-import se.lu.nateko.cp.meta.core.data.Person
-import se.lu.nateko.cp.meta.core.data.Position
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.Validated.CardinalityExpectation
-import se.lu.nateko.cp.meta.utils.Validated.validateSize
-import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, Funder, Orcid, Organization, Person, Position}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate}
 import se.lu.nateko.cp.meta.services.upload.DobjMetaReader
+import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
+import se.lu.nateko.cp.meta.utils.Validated
+import se.lu.nateko.cp.meta.utils.Validated.{CardinalityExpectation, validateSize}
+import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
 
 
 class MetaflowLenses(val cpLens: CpLens, val envriLens: MetaLens, val docLens: DocLens)

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RolesDiffCalc.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RolesDiffCalc.scala
@@ -1,7 +1,8 @@
 package se.lu.nateko.cp.meta.metaflow
 
-import scala.collection.mutable.Set
 import se.lu.nateko.cp.meta.api.UriId
+
+import scala.collection.mutable.Set
 
 object RolesDiffCalc{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/StateDiffApplier.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/StateDiffApplier.scala
@@ -1,12 +1,9 @@
 package se.lu.nateko.cp.meta.metaflow
 
 import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.CitiesMetaFlowConfig
-import se.lu.nateko.cp.meta.IcosMetaFlowConfig
-import se.lu.nateko.cp.meta.MetaDb
-import se.lu.nateko.cp.meta.MetaFlowConfig
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import org.slf4j.LoggerFactory
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.{CitiesMetaFlowConfig, IcosMetaFlowConfig, MetaDb, MetaFlowConfig}
 
 
 class StateDiffApplier(

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/TcMetadata.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/TcMetadata.scala
@@ -6,7 +6,7 @@ import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.data.{Funder, Funding, Orcid, Organization, Position, Station}
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 
-import java.time.{Instant, LocalDateTime}
+import java.time.Instant
 
 
 trait TC

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/TcMetadata.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/TcMetadata.scala
@@ -1,15 +1,12 @@
 package se.lu.nateko.cp.meta.metaflow
 
 import akka.stream.scaladsl.Source
-import java.time.Instant
-import java.time.LocalDateTime
 import org.eclipse.rdf4j.model.IRI
-
 import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.core.data.{Position, Orcid, Station}
-import se.lu.nateko.cp.meta.core.data.{Organization, Funding, Funder}
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.core.data.{Funder, Funding, Orcid, Organization, Position, Station}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+
+import java.time.{Instant, LocalDateTime}
 
 
 trait TC

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/TriggeredMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/TriggeredMetaSource.scala
@@ -1,17 +1,12 @@
 package se.lu.nateko.cp.meta.metaflow
 
-import scala.concurrent.duration.DurationInt
-
+import akka.actor.{ActorRef, Status}
 import akka.event.LoggingAdapter
-import akka.actor.ActorRef
-import akka.actor.Status
-import akka.stream.scaladsl.Source
-import akka.stream.CompletionStrategy
-import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.Keep
-import akka.stream.ThrottleMode
-
+import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.{CompletionStrategy, OverflowStrategy, ThrottleMode}
 import se.lu.nateko.cp.meta.utils.Validated
+
+import scala.concurrent.duration.DurationInt
 
 trait TriggeredMetaSource[T <: TC : TcConf] extends TcMetaSource[T] {
 	def log: LoggingAdapter

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesMetaFlow.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesMetaFlow.scala
@@ -4,18 +4,11 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.CitiesMetaFlowConfig
-import se.lu.nateko.cp.meta.MetaDb
-import se.lu.nateko.cp.meta.MetaUploadConf
-import se.lu.nateko.cp.meta.core.data.AtcStationSpecifics
-import se.lu.nateko.cp.meta.core.data.CountryCode
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.IcosCitiesStationSpecifics
+import se.lu.nateko.cp.meta.core.data.{AtcStationSpecifics, CountryCode, EnvriConfigs, IcosCitiesStationSpecifics}
 import se.lu.nateko.cp.meta.metaflow.*
-import se.lu.nateko.cp.meta.metaflow.icos.ATC
-import se.lu.nateko.cp.meta.metaflow.icos.AtcConf
-import se.lu.nateko.cp.meta.metaflow.icos.AtcMetaSource
+import se.lu.nateko.cp.meta.metaflow.icos.{ATC, AtcConf, AtcMetaSource}
 import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.{CitiesMetaFlowConfig, MetaDb, MetaUploadConf}
 
 object CitiesMetaFlow:
 	def init(

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesTcConf.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesTcConf.scala
@@ -1,9 +1,9 @@
 package se.lu.nateko.cp.meta.metaflow.cities
 
+import org.eclipse.rdf4j.model.IRI
+import se.lu.nateko.cp.meta.core.data.CityNetwork
 import se.lu.nateko.cp.meta.metaflow.{TC, TcConf}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.core.data.CityNetwork
-import org.eclipse.rdf4j.model.IRI
 
 
 sealed trait CitiesTC(val network: CityNetwork) extends TC

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/MidLowCostMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/MidLowCostMetaSource.scala
@@ -5,9 +5,9 @@ import se.lu.nateko.cp.meta.MetaUploadConf
 import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.metaflow.*
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.metaflow.icos.AtcMetaSource.{parseFromCsv, lookUpMandatory}
+import se.lu.nateko.cp.meta.metaflow.icos.AtcMetaSource.{lookUpMandatory, parseFromCsv}
 import se.lu.nateko.cp.meta.metaflow.icos.EtcMetaSource.{Lookup, dummyUri}
+import se.lu.nateko.cp.meta.utils.Validated
 
 class MidLowCostMetaSource[T <: CitiesTC : TcConf](
 	conf: MetaUploadConf,

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/AtcMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/AtcMetaSource.scala
@@ -5,20 +5,16 @@ import se.lu.nateko.cp.meta.MetaUploadConf
 import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.metaflow.*
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.Validated
 
-import java.io.BufferedInputStream
-import java.io.FileInputStream
-import java.io.InputStreamReader
+import java.io.{BufferedInputStream, FileInputStream, InputStreamReader}
 import java.net.URI
 import java.nio.file.Path
-import java.time.Instant
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
+import scala.util.Using
 
 import EtcMetaSource.{Lookup, lookUp, lookUpOrcid, dummyUri}
-import scala.util.Using
 
 class AtcMetaSource(conf: MetaUploadConf)(using ActorSystem) extends FileDropMetaSource[ATC.type](conf):
 	import AtcMetaSource.*

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/AtcMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/AtcMetaSource.scala
@@ -5,7 +5,7 @@ import se.lu.nateko.cp.meta.MetaUploadConf
 import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.metaflow.*
-import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
+import se.lu.nateko.cp.meta.services.CpVocab
 import se.lu.nateko.cp.meta.utils.Validated
 
 import java.io.{BufferedInputStream, FileInputStream, InputStreamReader}

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/EtcMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/EtcMetaSource.scala
@@ -11,7 +11,18 @@ import akka.util.ByteString
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.EtcConfig
 import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment as _, *}
+import se.lu.nateko.cp.meta.core.data.{
+   Orcid,
+   Position,
+   CountryCode,
+   Organization,
+   UriResource,
+   Funder,
+   Funding,
+   Station,
+   EtcStationSpecifics,
+   PositionUtil
+}
 import se.lu.nateko.cp.meta.core.etcupload.{DataType, StationId}
 import se.lu.nateko.cp.meta.ingestion.badm.{Badm, BadmLocalDate, BadmLocalDateTime, BadmYear}
 import se.lu.nateko.cp.meta.metaflow.*

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/EtcMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/EtcMetaSource.scala
@@ -1,43 +1,30 @@
 package se.lu.nateko.cp.meta.metaflow.icos
 
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.LocalTime
-import java.time.ZoneOffset
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, Uri}
+import akka.stream.scaladsl.Source
+import akka.stream.{ActorAttributes, Materializer, Supervision}
+import akka.util.ByteString
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.EtcConfig
+import se.lu.nateko.cp.meta.api.UriId
+import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment as _, *}
+import se.lu.nateko.cp.meta.core.etcupload.{DataType, StationId}
+import se.lu.nateko.cp.meta.ingestion.badm.{Badm, BadmLocalDate, BadmLocalDateTime, BadmYear}
+import se.lu.nateko.cp.meta.metaflow.*
+import se.lu.nateko.cp.meta.services.upload.etc.*
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.utils.Validated
+import se.lu.nateko.cp.meta.utils.rdf4j.*
 
+import java.net.URI
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime, ZoneOffset}
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 import scala.util.Failure
-
-import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.Uri
-import akka.stream.ActorAttributes
-import akka.stream.Materializer
-import akka.stream.Supervision
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
-import se.lu.nateko.cp.meta.EtcConfig
-import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.ingestion.badm.Badm
-import se.lu.nateko.cp.meta.ingestion.badm.BadmLocalDate
-import se.lu.nateko.cp.meta.ingestion.badm.BadmLocalDateTime
-import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment => _, *}
-import se.lu.nateko.cp.meta.core.etcupload.DataType
-import se.lu.nateko.cp.meta.core.etcupload.StationId
-import se.lu.nateko.cp.meta.metaflow.*
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.upload.etc.*
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.rdf4j.*
-import java.net.URI
-import se.lu.nateko.cp.meta.ingestion.badm.BadmYear
-import eu.icoscp.envri.Envri
-import akka.event.Logging
 
 
 class EtcMetaSource(conf: EtcConfig, vocab: CpVocab)(using system: ActorSystem, mat: Materializer) extends TcMetaSource[ETC.type] {

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/IcosMetaFlow.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/IcosMetaFlow.scala
@@ -3,14 +3,12 @@ package se.lu.nateko.cp.meta.metaflow.icos
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
-import se.lu.nateko.cp.meta.EtcConfig
-import se.lu.nateko.cp.meta.IcosMetaFlowConfig
-import se.lu.nateko.cp.meta.MetaDb
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import se.lu.nateko.cp.meta.instanceserver.WriteNotifyingInstanceServer
 import se.lu.nateko.cp.meta.metaflow.*
 import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
-import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.{EtcConfig, IcosMetaFlowConfig, MetaDb}
 
 
 object IcosMetaFlow:

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/OtcMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/OtcMetaSource.scala
@@ -1,32 +1,21 @@
 package se.lu.nateko.cp.meta.metaflow.icos
 
-import akka.actor.ActorRef
-import akka.actor.Status
+import akka.actor.{ActorRef, Status}
 import akka.event.LoggingAdapter
-import akka.stream.OverflowStrategy
-import akka.stream.ThrottleMode
-import akka.stream.scaladsl.Keep
-import akka.stream.scaladsl.Source
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
+import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.{OverflowStrategy, ThrottleMode}
 import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.model.{IRI, Literal, Value, ValueFactory}
 import org.eclipse.rdf4j.query.BindingSet
-import se.lu.nateko.cp.meta.api.CustomVocab
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
-import se.lu.nateko.cp.meta.api.UriId
+import se.lu.nateko.cp.meta.api.{CustomVocab, SparqlQuery, SparqlRunner, UriId}
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.instanceserver.WriteNotifyingInstanceServer
 import se.lu.nateko.cp.meta.metaflow.*
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import java.time.Instant
-import java.time.LocalDate
+import java.time.{Instant, LocalDate}
 import scala.concurrent.duration.DurationInt
 import scala.util.Try
 

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/OtcMetaSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/icos/OtcMetaSource.scala
@@ -1,9 +1,7 @@
 package se.lu.nateko.cp.meta.metaflow.icos
 
-import akka.actor.{ActorRef, Status}
+import akka.actor.ActorRef
 import akka.event.LoggingAdapter
-import akka.stream.scaladsl.{Keep, Source}
-import akka.stream.{OverflowStrategy, ThrottleMode}
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.model.{IRI, Literal, Value, ValueFactory}
 import org.eclipse.rdf4j.query.BindingSet
@@ -15,9 +13,7 @@ import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import java.time.{Instant, LocalDate}
-import scala.concurrent.duration.DurationInt
-import scala.util.Try
+import java.time.Instant
 
 class OtcMetaSource(
 	server: WriteNotifyingInstanceServer, sparql: SparqlRunner, val log: LoggingAdapter

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala
@@ -1,26 +1,16 @@
 package se.lu.nateko.cp.meta.onto
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.model.vocabulary.{OWL, RDF, RDFS, XSD}
+import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
 import org.eclipse.rdf4j.query.UpdateExecutionException
-import org.semanticweb.owlapi.model.{IRI => OwlIri}
+import org.semanticweb.owlapi.model.IRI as OwlIri
 import se.lu.nateko.cp.meta.*
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.net.URI
-import scala.util.Failure
-import scala.util.Try
 import scala.util.control.NoStackTrace
+import scala.util.{Failure, Try}
 
 import TriplestoreConnection.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/Onto.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/Onto.scala
@@ -1,18 +1,16 @@
 package se.lu.nateko.cp.meta.onto
 
-import java.net.URI
-
-import scala.collection.concurrent.TrieMap
-
 import org.semanticweb.owlapi.model.*
 import org.semanticweb.owlapi.model.parameters.Imports
 import org.semanticweb.owlapi.search.EntitySearcher
 import org.semanticweb.owlapi.vocab.OWLFacet
-
 import se.lu.nateko.cp.meta.*
 import se.lu.nateko.cp.meta.onto.labeler.*
 import se.lu.nateko.cp.meta.onto.reasoner.*
 import se.lu.nateko.cp.meta.utils.owlapi.*
+
+import java.net.URI
+import scala.collection.concurrent.TrieMap
 
 
 class Onto (owlOntology: OWLOntology) extends java.io.Closeable{

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/Vocab.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/Vocab.scala
@@ -1,11 +1,8 @@
 package se.lu.nateko.cp.meta.onto
 
-import org.semanticweb.owlapi.model.OWLDataFactory
 import org.semanticweb.owlapi.apibinding.OWLManager
+import org.semanticweb.owlapi.model.{IRI, OWLAnnotationProperty, OWLDataFactory, PrefixManager}
 import org.semanticweb.owlapi.util.DefaultPrefixManager
-import org.semanticweb.owlapi.model.PrefixManager
-import org.semanticweb.owlapi.model.OWLAnnotationProperty
-import org.semanticweb.owlapi.model.IRI
 
 object Vocab {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/ClassIndividualsLabeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/ClassIndividualsLabeler.scala
@@ -1,9 +1,10 @@
 package se.lu.nateko.cp.meta.onto.labeler
 
-import scala.jdk.CollectionConverters.*
 import org.semanticweb.owlapi.model.*
 import org.semanticweb.owlapi.search.EntitySearcher
 import se.lu.nateko.cp.meta.onto.Vocab
+
+import scala.jdk.CollectionConverters.*
 
 
 object ClassIndividualsLabeler{

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/Labeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/Labeler.scala
@@ -5,7 +5,6 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS
 import org.semanticweb.owlapi.model.{OWLAnnotationProperty, OWLEntity, OWLOntology}
 import org.semanticweb.owlapi.search.EntitySearcher
 import se.lu.nateko.cp.meta.ResourceDto
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{TSC, getValues}
 import se.lu.nateko.cp.meta.utils.owlapi.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/Labeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/Labeler.scala
@@ -2,14 +2,11 @@ package se.lu.nateko.cp.meta.onto.labeler
 
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.semanticweb.owlapi.model.OWLAnnotationProperty
-import org.semanticweb.owlapi.model.OWLEntity
-import org.semanticweb.owlapi.model.OWLOntology
+import org.semanticweb.owlapi.model.{OWLAnnotationProperty, OWLEntity, OWLOntology}
 import org.semanticweb.owlapi.search.EntitySearcher
 import se.lu.nateko.cp.meta.ResourceDto
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.TSC
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.getValues
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{TSC, getValues}
 import se.lu.nateko.cp.meta.utils.owlapi.*
 
 import scala.jdk.CollectionConverters.IteratorHasAsScala

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/MultiComponentIndividualLabeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/MultiComponentIndividualLabeler.scala
@@ -2,7 +2,6 @@ package se.lu.nateko.cp.meta.onto.labeler
 
 import org.eclipse.rdf4j.model.{IRI, Literal}
 import org.semanticweb.owlapi.model.{IRI as OWLIRI, *}
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{TSC, getValues}
 
 class MultiComponentIndividualLabeler(

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/MultiComponentIndividualLabeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/MultiComponentIndividualLabeler.scala
@@ -1,7 +1,7 @@
 package se.lu.nateko.cp.meta.onto.labeler
 
 import org.eclipse.rdf4j.model.{IRI, Literal}
-import org.semanticweb.owlapi.model.{IRI as OWLIRI, *}
+import org.semanticweb.owlapi.model.{IRI as OWLIRI, OWLObjectProperty}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{TSC, getValues}
 
 class MultiComponentIndividualLabeler(

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/MultiComponentIndividualLabeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/MultiComponentIndividualLabeler.scala
@@ -1,11 +1,9 @@
 package se.lu.nateko.cp.meta.onto.labeler
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.semanticweb.owlapi.model.{IRI => OWLIRI, _}
+import org.eclipse.rdf4j.model.{IRI, Literal}
+import org.semanticweb.owlapi.model.{IRI as OWLIRI, *}
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.TSC
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.getValues
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{TSC, getValues}
 
 class MultiComponentIndividualLabeler(
 	components: Seq[DisplayComponent],

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/UniversalLabeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/UniversalLabeler.scala
@@ -1,8 +1,7 @@
 package se.lu.nateko.cp.meta.onto.labeler
 
 import org.eclipse.rdf4j.model.IRI
-import org.semanticweb.owlapi.model.OWLOntology
-import org.semanticweb.owlapi.model.{IRI => OwlIri}
+import org.semanticweb.owlapi.model.{IRI as OwlIri, OWLOntology}
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.TSC
 import se.lu.nateko.cp.meta.onto.InstOnto

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/UniversalLabeler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/labeler/UniversalLabeler.scala
@@ -2,7 +2,6 @@ package se.lu.nateko.cp.meta.onto.labeler
 
 import org.eclipse.rdf4j.model.IRI
 import org.semanticweb.owlapi.model.{IRI as OwlIri, OWLOntology}
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.TSC
 import se.lu.nateko.cp.meta.onto.InstOnto
 import se.lu.nateko.cp.meta.utils.rdf4j.*

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/reasoner/BaseReasoner.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/reasoner/BaseReasoner.scala
@@ -1,14 +1,10 @@
 package se.lu.nateko.cp.meta.onto.reasoner
 
-import scala.jdk.CollectionConverters.{IteratorHasAsScala, SeqHasAsJava}
-import org.semanticweb.owlapi.search.EntitySearcher
 import org.semanticweb.owlapi.model.parameters.Imports
-import org.semanticweb.owlapi.model.OWLOntology
-import org.semanticweb.owlapi.model.OWLClass
-import org.semanticweb.owlapi.model.OWLClassExpression
-import org.semanticweb.owlapi.model.OWLProperty
-import org.semanticweb.owlapi.model.OWLDataProperty
-import org.semanticweb.owlapi.model.OWLObjectProperty
+import org.semanticweb.owlapi.model.{OWLClass, OWLClassExpression, OWLDataProperty, OWLObjectProperty, OWLOntology, OWLProperty}
+import org.semanticweb.owlapi.search.EntitySearcher
+
+import scala.jdk.CollectionConverters.{IteratorHasAsScala, SeqHasAsJava}
 
 abstract class BaseReasoner(ontology: OWLOntology) extends Reasoner {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/reasoner/HermitBasedReasoner.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/reasoner/HermitBasedReasoner.scala
@@ -1,12 +1,8 @@
 package se.lu.nateko.cp.meta.onto.reasoner
 
+import org.semanticweb.owlapi.model.{OWLClass, OWLClassExpression, OWLDataProperty, OWLObjectProperty, OWLOntology, OWLProperty}
+
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-import org.semanticweb.owlapi.model.OWLClass
-import org.semanticweb.owlapi.model.OWLProperty
-import org.semanticweb.owlapi.model.OWLClassExpression
-import org.semanticweb.owlapi.model.OWLOntology
-import org.semanticweb.owlapi.model.OWLDataProperty
-import org.semanticweb.owlapi.model.OWLObjectProperty
 
 
 class HermitBasedReasoner(ontology: OWLOntology) extends BaseReasoner(ontology){

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/reasoner/Reasoner.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/reasoner/Reasoner.scala
@@ -1,8 +1,6 @@
 package se.lu.nateko.cp.meta.onto.reasoner
 
-import org.semanticweb.owlapi.model.OWLClass
-import org.semanticweb.owlapi.model.OWLProperty
-import org.semanticweb.owlapi.model.OWLClassExpression
+import org.semanticweb.owlapi.model.{OWLClass, OWLClassExpression, OWLProperty}
 
 trait Reasoner extends java.io.Closeable{
 	def getSuperClasses(owlClass: OWLClass, direct: Boolean): Seq[OWLClassExpression]

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/InMemoryRdfLog.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/InMemoryRdfLog.scala
@@ -1,9 +1,10 @@
 package se.lu.nateko.cp.meta.persistence
 
+import se.lu.nateko.cp.meta.api.CloseableIterator
+import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
+
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters.*
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.api.CloseableIterator
 
 class InMemoryRdfLog extends RdfUpdateLog{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/RdfUpdateLog.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/RdfUpdateLog.scala
@@ -1,8 +1,9 @@
 package se.lu.nateko.cp.meta.persistence
 
-import java.io.Closeable
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
 import se.lu.nateko.cp.meta.api.CloseableIterator
+import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
+
+import java.io.Closeable
 import java.time.Instant
 
 trait RdfUpdateLog extends Closeable{

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/RdfUpdateLogIngester.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/RdfUpdateLogIngester.scala
@@ -3,14 +3,11 @@ package se.lu.nateko.cp.meta.persistence
 import org.eclipse.rdf4j.common.transaction.IsolationLevels
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.repository.Repository
-
-import scala.util.Try
-import scala.util.Failure
-
 import se.lu.nateko.cp.meta.api.CloseableIterator
 import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import scala.util.Using
+
+import scala.util.{Failure, Try, Using}
 
 
 object RdfUpdateLogIngester:

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/RdfUpdateLogIngester.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/RdfUpdateLogIngester.scala
@@ -1,13 +1,11 @@
 package se.lu.nateko.cp.meta.persistence
-
-import org.eclipse.rdf4j.common.transaction.IsolationLevels
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.repository.Repository
 import se.lu.nateko.cp.meta.api.CloseableIterator
 import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import scala.util.{Failure, Try, Using}
+import scala.util.{Try, Using}
 
 
 object RdfUpdateLogIngester:

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/Postgres.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/Postgres.scala
@@ -1,8 +1,6 @@
 package se.lu.nateko.cp.meta.persistence.postgres
 
-import java.sql.Connection
-import java.sql.DriverManager
-
+import java.sql.{Connection, DriverManager}
 import scala.util.Try
 
 case class DbCredentials(db: String, user: String, password: String)

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/PostgresRdfLog.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/PostgresRdfLog.scala
@@ -1,16 +1,13 @@
 package se.lu.nateko.cp.meta.persistence.postgres
 
-import java.sql.BatchUpdateException
-import java.sql.PreparedStatement
-import java.sql.Timestamp
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.XSD
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.persistence.RdfUpdateLog
+import org.eclipse.rdf4j.model.{IRI, Literal, ValueFactory}
 import se.lu.nateko.cp.meta.RdflogConfig
 import se.lu.nateko.cp.meta.api.CloseableIterator
+import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
+import se.lu.nateko.cp.meta.persistence.RdfUpdateLog
+
+import java.sql.{BatchUpdateException, PreparedStatement, Timestamp}
 import java.time.Instant
 
 class PostgresRdfLog(logName: String, serv: DbServer, creds: DbCredentials, factory: ValueFactory) extends RdfUpdateLog{

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/RdfUpdateResultSetIterator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/RdfUpdateResultSetIterator.scala
@@ -1,13 +1,9 @@
 package se.lu.nateko.cp.meta.persistence.postgres
 
-import java.sql.ResultSet
-
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-
+import org.eclipse.rdf4j.model.{IRI, Value, ValueFactory}
 import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import java.sql.Connection
+
+import java.sql.{Connection, ResultSet}
 import java.time.Instant
 
 class RdfUpdateResultSetIterator(getConn: () => Connection, factory: ValueFactory, selectQuery: String){

--- a/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/ResultSetIterator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/persistence/postgres/ResultSetIterator.scala
@@ -1,8 +1,8 @@
 package se.lu.nateko.cp.meta.persistence.postgres
 
-import java.sql.ResultSet
 import se.lu.nateko.cp.meta.api.CloseableIterator
-import java.sql.Connection
+
+import java.sql.{Connection, ResultSet}
 
 class ResultSetIterator[T](connectionFactory: () => Connection, resultFactory: ResultSet => T, selectQuery: String) extends CloseableIterator[T]{
 	private val conn = connectionFactory()

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/AdminRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/AdminRouting.scala
@@ -1,6 +1,4 @@
 package se.lu.nateko.cp.meta.routes
-
-import akka.Done
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
@@ -9,7 +7,7 @@ import akka.util.ByteString
 import org.eclipse.rdf4j.model.{IRI, Statement}
 import org.eclipse.rdf4j.repository.Repository
 import se.lu.nateko.cp.meta.SparqlServerConfig
-import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
+import se.lu.nateko.cp.meta.api.SparqlQuery
 import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate}
 import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
 import se.lu.nateko.cp.meta.utils.rdf4j.{Rdf4jStatement, transact}

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/AdminRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/AdminRouting.scala
@@ -1,28 +1,21 @@
 package se.lu.nateko.cp.meta.routes
 
 import akka.Done
-import akka.http.scaladsl.model.ContentTypes
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.model.{IRI, Statement}
 import org.eclipse.rdf4j.repository.Repository
 import se.lu.nateko.cp.meta.SparqlServerConfig
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate}
 import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
-import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement
-import se.lu.nateko.cp.meta.utils.rdf4j.transact
+import se.lu.nateko.cp.meta.utils.rdf4j.{Rdf4jStatement, transact}
 
 import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
+import scala.util.{Failure, Success}
 
 
 class AdminRouting(

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/AuthenticationRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/AuthenticationRouting.scala
@@ -1,31 +1,18 @@
 package se.lu.nateko.cp.meta.routes
 
-import scala.language.implicitConversions
-
-import se.lu.nateko.cp.cpauth.core.Authenticator
-import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.cpauth.core.CookieToToken
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.server.StandardRoute
-import akka.http.scaladsl.server.Directives.*
-import akka.http.scaladsl.server.Directive0
-import akka.http.scaladsl.server.Directive1
-import se.lu.nateko.cp.cpauth.core.PublicAuthConfig
-
-import scala.util.Success
-import scala.util.Failure
-import akka.http.scaladsl.model.StatusCodes
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import akka.http.scaladsl.server.Rejection
-import akka.http.scaladsl.server.RejectionHandler
-import akka.http.scaladsl.model.headers.`X-Forwarded-For`
-import spray.json.JsObject
-import spray.json.JsNull
-import se.lu.nateko.cp.meta.core.data.{EnvriResolver, EnvriConfigs}
-import akka.http.scaladsl.model.headers.HttpCookie
-import akka.http.scaladsl.model.headers.SameSite
 import akka.http.javadsl.server.MissingCookieRejection
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.{HttpCookie, SameSite, `X-Forwarded-For`}
+import akka.http.scaladsl.server.Directives.*
+import akka.http.scaladsl.server.{Directive0, Directive1, Rejection, RejectionHandler, Route, StandardRoute}
 import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.cpauth.core.{Authenticator, CookieToToken, PublicAuthConfig, UserId}
+import se.lu.nateko.cp.meta.CpmetaJsonProtocol
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, EnvriResolver}
+import spray.json.{JsNull, JsObject}
+
+import scala.language.implicitConversions
+import scala.util.{Failure, Success}
 
 class AuthenticationRouting(authConf: Map[Envri, PublicAuthConfig])(using EnvriConfigs) extends CpmetaJsonProtocol{
 	import AuthenticationRouting.*

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/DoiRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/DoiRoute.scala
@@ -1,5 +1,6 @@
 package se.lu.nateko.cp.meta.routes
 
+import akka.event.{Logging, LoggingBus}
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
@@ -12,7 +13,6 @@ import se.lu.nateko.cp.meta.services.upload.*
 
 import java.net.URI
 import scala.language.implicitConversions
-import akka.event.{Logging, LoggingBus}
 
 object DoiRoute extends CpmetaJsonProtocol{
 	def apply(

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/DtoDownloadRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/DtoDownloadRoute.scala
@@ -1,6 +1,4 @@
 package se.lu.nateko.cp.meta.routes
-
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
 import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/DtoDownloadRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/DtoDownloadRoute.scala
@@ -1,19 +1,18 @@
 package se.lu.nateko.cp.meta.routes
 
-import scala.language.implicitConversions
-
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.{StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives.*
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling.Unmarshaller
-import scala.concurrent.Future
-import scala.util.Try
-import se.lu.nateko.cp.meta.core.CommonJsonSupport.WithErrors
 import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
+import se.lu.nateko.cp.meta.core.CommonJsonSupport.WithErrors
 import se.lu.nateko.cp.meta.services.UploadDtoReader
+import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
+
+import scala.concurrent.Future
+import scala.language.implicitConversions
+import scala.util.Try
 
 object DtoDownloadRoute extends CpmetaJsonProtocol{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/FilesRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/FilesRoute.scala
@@ -1,11 +1,10 @@
 package se.lu.nateko.cp.meta.routes
 
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.Directives.*
-import se.lu.nateko.cp.meta.services.FileStorageService
 import akka.http.scaladsl.server.directives.ContentTypeResolver
+import akka.http.scaladsl.server.{PathMatcher1, Route}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import akka.http.scaladsl.server.PathMatcher1
+import se.lu.nateko.cp.meta.services.FileStorageService
 
 object FilesRoute {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/LabelingApiRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/LabelingApiRoute.scala
@@ -1,6 +1,6 @@
 package se.lu.nateko.cp.meta.routes
 
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, Multipart, ResponseEntity, StatusCodes}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, Multipart, StatusCodes}
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
@@ -10,8 +10,7 @@ import akka.util.ByteString
 import se.lu.nateko.cp.meta.services.labeling.{StationLabelingHistory, StationLabelingService}
 import se.lu.nateko.cp.meta.services.{IllegalLabelingStatusException, UnauthorizedStationUpdateException, UnauthorizedUserInfoUpdateException}
 import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, FileDeletionDto, LabelingStatusUpdate, LabelingUserDto}
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
-import spray.json.{JsObject, RootJsonReader}
+import spray.json.JsObject
 
 import java.net.URI
 import java.nio.charset.StandardCharsets

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/LabelingApiRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/LabelingApiRoute.scala
@@ -1,38 +1,24 @@
 package se.lu.nateko.cp.meta.routes
 
-import scala.language.implicitConversions
-
-import akka.http.scaladsl.model.ContentTypes
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.Multipart
-import akka.http.scaladsl.model.ResponseEntity
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, Multipart, ResponseEntity, StatusCodes}
 import akka.http.scaladsl.server.Directives.*
-import akka.http.scaladsl.server.ExceptionHandler
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.FileDeletionDto
-import se.lu.nateko.cp.meta.LabelingStatusUpdate
-import se.lu.nateko.cp.meta.LabelingUserDto
-import se.lu.nateko.cp.meta.services.IllegalLabelingStatusException
-import se.lu.nateko.cp.meta.services.UnauthorizedStationUpdateException
-import se.lu.nateko.cp.meta.services.UnauthorizedUserInfoUpdateException
-import se.lu.nateko.cp.meta.services.labeling.StationLabelingHistory
-import se.lu.nateko.cp.meta.services.labeling.StationLabelingService
-import spray.json.JsObject
+import se.lu.nateko.cp.meta.services.labeling.{StationLabelingHistory, StationLabelingService}
+import se.lu.nateko.cp.meta.services.{IllegalLabelingStatusException, UnauthorizedStationUpdateException, UnauthorizedUserInfoUpdateException}
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, FileDeletionDto, LabelingStatusUpdate, LabelingUserDto}
+import spray.json.DefaultJsonProtocol.RootJsObjectFormat
+import spray.json.{JsObject, RootJsonReader}
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
+import scala.language.implicitConversions
 import scala.util.Try
-import spray.json.RootJsonReader
-import spray.json.DefaultJsonProtocol.RootJsObjectFormat
 
 object LabelingApiRoute extends CpmetaJsonProtocol:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/LinkedDataRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/LinkedDataRoute.scala
@@ -1,24 +1,22 @@
 package se.lu.nateko.cp.meta.routes
 
-import scala.language.postfixOps
+import akka.event.{Logging, LoggingBus}
+import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.*
 import akka.http.scaladsl.model.headers.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
-import se.lu.nateko.cp.meta.InstanceServersConfig
-import se.lu.nateko.cp.meta.MetaDb
-import se.lu.nateko.cp.meta.core.data.DataObject
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.core.data.{DataObject, EnvriConfigs}
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.routes.FilesRoute.Sha256Segment
 import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.linkeddata.InstanceServerSerializer
-import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
+import se.lu.nateko.cp.meta.services.linkeddata.{InstanceServerSerializer, UriSerializer}
 import se.lu.nateko.cp.meta.services.metaexport.Inspire
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import eu.icoscp.envri.Envri
-import akka.event.{LoggingBus, Logging}
+import se.lu.nateko.cp.meta.{InstanceServersConfig, MetaDb}
+
+import scala.language.postfixOps
 
 object LinkedDataRoute {
 	private given ToResponseMarshaller[InstanceServer] = InstanceServerSerializer.marshaller

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/MainRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/MainRoute.scala
@@ -1,25 +1,21 @@
 package se.lu.nateko.cp.meta.routes
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
+import akka.event.LoggingBus
+import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshaller}
 import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.Directives.*
-import akka.http.scaladsl.server.ExceptionHandler
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import akka.stream.Materializer
-import se.lu.nateko.cp.meta.CpmetaConfig
-import se.lu.nateko.cp.meta.MetaDb
 import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
 import se.lu.nateko.cp.meta.metaflow.MetaFlow
 import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
 import se.lu.nateko.cp.meta.services.upload.DoiService
 import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling.errorMarshaller
+import se.lu.nateko.cp.meta.{CpmetaConfig, MetaDb}
 
 import scala.concurrent.ExecutionContext
-import akka.event.LoggingBus
 
 object MainRoute {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/MetadataEntryRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/MetadataEntryRouting.scala
@@ -1,15 +1,13 @@
 package se.lu.nateko.cp.meta.routes
 
-import se.lu.nateko.cp.meta.onto.InstOnto
+import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.model.*
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.UpdateDto
-import se.lu.nateko.cp.meta.ReplaceDto
-import java.net.URI
-import se.lu.nateko.cp.meta.InstOntoServerConfig
+import se.lu.nateko.cp.meta.onto.InstOnto
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, InstOntoServerConfig, ReplaceDto, UpdateDto}
 import spray.json.*
+
+import java.net.URI
 import scala.language.implicitConversions
 
 class MetadataEntryRouting(authRouting: AuthenticationRouting) extends CpmetaJsonProtocol{

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/SitemapRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/SitemapRoute.scala
@@ -4,12 +4,9 @@ import akka.http.scaladsl.model.*
 import akka.http.scaladsl.model.headers.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
-import se.lu.nateko.cp.meta.api.SparqlRunner
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, envriConf}
 import se.lu.nateko.cp.meta.services.metaexport.SchemaOrg
-import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.core.data.envriConf
 
 object SitemapRoute {
 	def apply(sparqler: SparqlRunner)(using EnvriConfigs): Route = {

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/SitemapRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/SitemapRoute.scala
@@ -1,10 +1,9 @@
 package se.lu.nateko.cp.meta.routes
 
 import akka.http.scaladsl.model.*
-import akka.http.scaladsl.model.headers.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
-import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
+import se.lu.nateko.cp.meta.api.SparqlRunner
 import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, envriConf}
 import se.lu.nateko.cp.meta.services.metaexport.SchemaOrg
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/StaticRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/StaticRoute.scala
@@ -3,16 +3,13 @@ package se.lu.nateko.cp.meta.routes
 import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
+import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.{IRI, Literal}
 import play.twirl.api.Html
 import se.lu.nateko.cp.cpauth.core.PublicAuthConfig
 import se.lu.nateko.cp.meta.OntoConfig
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
-import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.Licence
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, Licence}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling
 import se.lu.nateko.cp.meta.utils.rdf4j.*
@@ -20,7 +17,6 @@ import se.lu.nateko.cp.meta.utils.rdf4j.*
 import java.net.URI
 import scala.language.postfixOps
 import scala.util.Using
-import eu.icoscp.envri.Envri
 
 object StaticRoute {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/StaticRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/StaticRoute.scala
@@ -6,10 +6,9 @@ import akka.http.scaladsl.server.Route
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.{IRI, Literal}
 import play.twirl.api.Html
-import se.lu.nateko.cp.cpauth.core.PublicAuthConfig
 import se.lu.nateko.cp.meta.OntoConfig
 import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
-import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, Licence}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling
 import se.lu.nateko.cp.meta.utils.rdf4j.*

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/UploadApiRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/UploadApiRoute.scala
@@ -3,36 +3,26 @@ package se.lu.nateko.cp.meta.routes
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
 import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.Directives.*
-import akka.http.scaladsl.server.ExceptionHandler
-import akka.http.scaladsl.server.MalformedRequestContentRejection
-import akka.http.scaladsl.server.RejectionHandler
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{ExceptionHandler, MalformedRequestContentRejection, RejectionHandler, Route}
 import akka.stream.Materializer
 import akka.stream.scaladsl.Keep
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.StaticCollectionDto
 import se.lu.nateko.cp.meta.core.MetaCoreConfig
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.DataObject
-import se.lu.nateko.cp.meta.core.data.DocObject
-import se.lu.nateko.cp.meta.core.data.GeoFeature
 import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.meta.core.data.UploadCompletionInfo
-import se.lu.nateko.cp.meta.core.etcupload.EtcUploadMetadata
+import se.lu.nateko.cp.meta.core.data.{DataObject, DocObject, EnvriConfigs, GeoFeature, UploadCompletionInfo}
 import se.lu.nateko.cp.meta.core.etcupload.JsonSupport.given
-import se.lu.nateko.cp.meta.core.etcupload.StationId
+import se.lu.nateko.cp.meta.core.etcupload.{EtcUploadMetadata, StationId}
 import se.lu.nateko.cp.meta.metaflow.MetaUploadService
 import se.lu.nateko.cp.meta.metaflow.icos.AtcMetaSource
 import se.lu.nateko.cp.meta.services.*
 import se.lu.nateko.cp.meta.services.upload.*
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, ObjectUploadDto, StaticCollectionDto}
 
 import java.net.URI
 import scala.collection.immutable.Seq
 import scala.concurrent.Future
 import scala.language.implicitConversions
 import scala.util.Try
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 
 object UploadApiRoute extends CpmetaJsonProtocol{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/UploadApiRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/UploadApiRoute.scala
@@ -1,6 +1,4 @@
 package se.lu.nateko.cp.meta.routes
-
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
 import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.{ExceptionHandler, MalformedRequestContentRejection, RejectionHandler, Route}
@@ -9,11 +7,10 @@ import akka.stream.scaladsl.Keep
 import se.lu.nateko.cp.meta.core.MetaCoreConfig
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.meta.core.data.{DataObject, DocObject, EnvriConfigs, GeoFeature, UploadCompletionInfo}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfigs, UploadCompletionInfo}
+import se.lu.nateko.cp.meta.core.etcupload.EtcUploadMetadata
 import se.lu.nateko.cp.meta.core.etcupload.JsonSupport.given
-import se.lu.nateko.cp.meta.core.etcupload.{EtcUploadMetadata, StationId}
 import se.lu.nateko.cp.meta.metaflow.MetaUploadService
-import se.lu.nateko.cp.meta.metaflow.icos.AtcMetaSource
 import se.lu.nateko.cp.meta.services.*
 import se.lu.nateko.cp.meta.services.upload.*
 import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, ObjectUploadDto, StaticCollectionDto}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/CpVocab.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/CpVocab.scala
@@ -1,28 +1,16 @@
 package se.lu.nateko.cp.meta.services
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
-import se.lu.nateko.cp.meta.api.CustomVocab
-import se.lu.nateko.cp.meta.api.UriId
+import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
+import se.lu.nateko.cp.meta.api.{CustomVocab, UriId}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-
-import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.IcosStationSpecifics
-import se.lu.nateko.cp.meta.core.data.Position
-import se.lu.nateko.cp.meta.core.data.collectionPrefix
-import se.lu.nateko.cp.meta.core.data.objectPathPrefix
-import se.lu.nateko.cp.meta.core.data.objectPrefix
-import se.lu.nateko.cp.meta.core.data.staticCollLandingPage
-import se.lu.nateko.cp.meta.core.data.staticObjAccessUrl
-import se.lu.nateko.cp.meta.core.data.staticObjLandingPage
-import se.lu.nateko.cp.meta.core.etcupload.{ StationId => EtcStationId }
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, IcosStationSpecifics, Position, collectionPrefix, objectPathPrefix, objectPrefix, staticCollLandingPage, staticObjAccessUrl, staticObjLandingPage}
+import se.lu.nateko.cp.meta.core.etcupload.StationId as EtcStationId
 import se.lu.nateko.cp.meta.metaflow.icos.{ETC, EtcConf}
-import se.lu.nateko.cp.meta.metaflow.{TC, Role, TcConf, TcId}
+import se.lu.nateko.cp.meta.metaflow.{Role, TC, TcConf, TcId}
 import se.lu.nateko.cp.meta.utils.rdf4j.===
 
 import java.net.URI
-import eu.icoscp.envri.Envri
 
 class CpVocab (val factory: ValueFactory)(using envriConfigs: EnvriConfigs) extends CustomVocab:
 	import CpVocab.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/CpVocab.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/CpVocab.scala
@@ -4,7 +4,7 @@ import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.meta.api.{CustomVocab, UriId}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, IcosStationSpecifics, Position, collectionPrefix, objectPathPrefix, objectPrefix, staticCollLandingPage, staticObjAccessUrl, staticObjLandingPage}
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs, IcosStationSpecifics, Position, staticCollLandingPage, staticObjAccessUrl, staticObjLandingPage}
 import se.lu.nateko.cp.meta.core.etcupload.StationId as EtcStationId
 import se.lu.nateko.cp.meta.metaflow.icos.{ETC, EtcConf}
 import se.lu.nateko.cp.meta.metaflow.{Role, TC, TcConf, TcId}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/CpmetaVocab.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/CpmetaVocab.scala
@@ -1,9 +1,10 @@
 package se.lu.nateko.cp.meta.services
 
 import org.eclipse.rdf4j.model.ValueFactory
-import se.lu.nateko.cp.meta.api.CustomVocab
-import java.net.URI
 import se.lu.nateko.cp.meta.OntoConstants.*
+import se.lu.nateko.cp.meta.api.CustomVocab
+
+import java.net.URI
 
 class CpmetaVocab (val factory: ValueFactory) extends CustomVocab { top =>
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/FileStorageService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/FileStorageService.scala
@@ -1,16 +1,14 @@
 package se.lu.nateko.cp.meta.services
 
-import java.io.File
+import akka.stream.scaladsl.{FileIO, Source}
 import akka.util.ByteString
-import java.security.MessageDigest
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.StandardOpenOption.*
-import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.FileIO
-import se.lu.nateko.cp.meta.utils.streams.ZipEntryFlow
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.utils.streams.ZipEntryFlow
+
+import java.io.File
+import java.nio.file.StandardOpenOption.*
+import java.nio.file.{Files, Path, Paths}
+import java.security.MessageDigest
 
 class FileStorageService(folder: File) {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/Rdf4jSparqlRunner.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/Rdf4jSparqlRunner.scala
@@ -1,13 +1,9 @@
 package se.lu.nateko.cp.meta.services
 
 import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.query.BindingSet
-import org.eclipse.rdf4j.query.QueryLanguage
+import org.eclipse.rdf4j.query.{BindingSet, QueryLanguage}
 import org.eclipse.rdf4j.repository.Repository
-
-import se.lu.nateko.cp.meta.api.CloseableIterator
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
+import se.lu.nateko.cp.meta.api.{CloseableIterator, SparqlQuery, SparqlRunner}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 class Rdf4jSparqlRunner(repo: Repository) extends SparqlRunner {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
@@ -2,27 +2,17 @@ package se.lu.nateko.cp.meta.services
 
 import akka.http.scaladsl.model.Uri
 import se.lu.nateko.cp.doi.Doi
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.DataProductionDto
-import se.lu.nateko.cp.meta.DocObjectDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.ReferencesDto
-import se.lu.nateko.cp.meta.SpatioTemporalDto
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.StationTimeSeriesDto
-import se.lu.nateko.cp.meta.UploadDto
-import se.lu.nateko.cp.meta.GeoJsonString
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
 import se.lu.nateko.cp.meta.utils.*
+import se.lu.nateko.cp.meta.{DataObjectDto, DataProductionDto, DocObjectDto, GeoCoverage, GeoJsonString, ObjectUploadDto, ReferencesDto, SpatioTemporalDto, StaticCollectionDto, StationTimeSeriesDto, UploadDto}
 
 import java.net.URI
 import java.time.Instant
 import scala.util.Success
 
 import UriSerializer.Hash
-import se.lu.nateko.cp.meta.GeoCoverage
 
 class UploadDtoReader(uriSer: UriSerializer){
 	import UploadDtoReader.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
@@ -6,7 +6,7 @@ import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
 import se.lu.nateko.cp.meta.utils.*
-import se.lu.nateko.cp.meta.{DataObjectDto, DataProductionDto, DocObjectDto, GeoCoverage, GeoJsonString, ObjectUploadDto, ReferencesDto, SpatioTemporalDto, StaticCollectionDto, StationTimeSeriesDto, UploadDto}
+import se.lu.nateko.cp.meta.{DataObjectDto, DataProductionDto, DocObjectDto, GeoCoverage, ReferencesDto, SpatioTemporalDto, StaticCollectionDto, StationTimeSeriesDto, UploadDto}
 
 import java.net.URI
 import java.time.Instant

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/AttributionProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/AttributionProvider.scala
@@ -1,35 +1,21 @@
 package se.lu.nateko.cp.meta.services.citation
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.model.{IRI, Literal, ValueFactory}
 import se.lu.nateko.cp.meta.api.RdfLens.MetaConn
-import se.lu.nateko.cp.meta.core.data.Agent
-import se.lu.nateko.cp.meta.core.data.DataObject
-import se.lu.nateko.cp.meta.core.data.DataTheme
-import se.lu.nateko.cp.meta.core.data.Orcid
-import se.lu.nateko.cp.meta.core.data.Organization
-import se.lu.nateko.cp.meta.core.data.Person
-import se.lu.nateko.cp.meta.core.data.Station
-import se.lu.nateko.cp.meta.core.data.UriResource
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.metaflow.Administrator
-import se.lu.nateko.cp.meta.metaflow.PI
-import se.lu.nateko.cp.meta.metaflow.Role
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.core.data.{Agent, DataObject, DataTheme, Orcid, Organization, Person, Station, UriResource}
+import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.metaflow.{Administrator, PI, Role}
 import se.lu.nateko.cp.meta.services.upload.CpmetaReader
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.net.URI
 import java.time.Instant
-import java.{util => ju}
+import java.util as ju
 import scala.collection.mutable
-import scala.util.Try
-import scala.util.Using
+import scala.util.{Try, Using}
 
 final class AttributionProvider(vocab: CpVocab, val metaVocab: CpmetaVocab) extends CpmetaReader:
 	import AttributionProvider.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/AttributionProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/AttributionProvider.scala
@@ -1,11 +1,8 @@
 package se.lu.nateko.cp.meta.services.citation
-
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.model.{IRI, Literal, ValueFactory}
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.meta.api.RdfLens.MetaConn
-import se.lu.nateko.cp.meta.core.data.{Agent, DataObject, DataTheme, Orcid, Organization, Person, Station, UriResource}
-import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
-import se.lu.nateko.cp.meta.metaflow.{Administrator, PI, Role}
+import se.lu.nateko.cp.meta.core.data.{Agent, DataObject, Organization, Person, UriResource}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.services.upload.CpmetaReader
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.Validated
@@ -13,9 +10,6 @@ import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.net.URI
 import java.time.Instant
-import java.util as ju
-import scala.collection.mutable
-import scala.util.{Try, Using}
 
 final class AttributionProvider(vocab: CpVocab, val metaVocab: CpmetaVocab) extends CpmetaReader:
 	import AttributionProvider.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationClient.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationClient.scala
@@ -1,42 +1,31 @@
 package se.lu.nateko.cp.meta.services.citation
 
-import spray.json.RootJsonFormat
-
 import akka.Done
 import akka.actor.ActorSystem
-import akka.event.LoggingAdapter
+import akka.event.{Logging, LoggingAdapter}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import se.lu.nateko.cp.doi.Doi
-import se.lu.nateko.cp.doi.DoiMeta
-import se.lu.nateko.cp.doi.core.JsonSupport.{given RootJsonFormat[DoiMeta]}
-import se.lu.nateko.cp.doi.core.JsonSupport.{given RootJsonFormat[Doi]}
+import org.slf4j.LoggerFactory
+import se.lu.nateko.cp.doi.core.JsonSupport.{given RootJsonFormat[DoiMeta], given RootJsonFormat[Doi]}
+import se.lu.nateko.cp.doi.{Doi, DoiMeta}
 import se.lu.nateko.cp.meta.CitationConfig
 import se.lu.nateko.cp.meta.services.upload.DoiClientFactory
-import se.lu.nateko.cp.meta.utils.Mergeable
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.async.errorLite
-import se.lu.nateko.cp.meta.utils.async.timeLimit
+import se.lu.nateko.cp.meta.utils.async.{errorLite, timeLimit}
+import se.lu.nateko.cp.meta.utils.{Mergeable, Validated}
+import spray.json.RootJsonFormat
 
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.StandardOpenOption
+import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import java.util.concurrent.TimeoutException
 import scala.collection.concurrent.TrieMap
-import scala.concurrent._
+import scala.concurrent.*
 import scala.concurrent.duration.DurationInt
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
 import scala.util.control.NoStackTrace
+import scala.util.{Failure, Success, Try}
 
 import CitationClient.*
-import akka.event.Logging
-import org.slf4j.LoggerFactory
 
 
 enum CitationStyle:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationClient.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationClient.scala
@@ -1,31 +1,42 @@
 package se.lu.nateko.cp.meta.services.citation
 
+import spray.json.RootJsonFormat
+
 import akka.Done
 import akka.actor.ActorSystem
-import akka.event.{Logging, LoggingAdapter}
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import org.slf4j.LoggerFactory
-import se.lu.nateko.cp.doi.core.JsonSupport.{given RootJsonFormat[DoiMeta], given RootJsonFormat[Doi]}
-import se.lu.nateko.cp.doi.{Doi, DoiMeta}
+import se.lu.nateko.cp.doi.Doi
+import se.lu.nateko.cp.doi.DoiMeta
+import se.lu.nateko.cp.doi.core.JsonSupport.{given RootJsonFormat[DoiMeta]}
+import se.lu.nateko.cp.doi.core.JsonSupport.{given RootJsonFormat[Doi]}
 import se.lu.nateko.cp.meta.CitationConfig
 import se.lu.nateko.cp.meta.services.upload.DoiClientFactory
-import se.lu.nateko.cp.meta.utils.async.{errorLite, timeLimit}
-import se.lu.nateko.cp.meta.utils.{Mergeable, Validated}
-import spray.json.RootJsonFormat
+import se.lu.nateko.cp.meta.utils.Mergeable
+import se.lu.nateko.cp.meta.utils.Validated
+import se.lu.nateko.cp.meta.utils.async.errorLite
+import se.lu.nateko.cp.meta.utils.async.timeLimit
 
-import java.nio.file.{Files, Path, Paths, StandardOpenOption}
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardOpenOption
 import java.util.concurrent.TimeoutException
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.*
+import scala.concurrent._
 import scala.concurrent.duration.DurationInt
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 import scala.util.control.NoStackTrace
-import scala.util.{Failure, Success, Try}
 
 import CitationClient.*
+import akka.event.Logging
+import org.slf4j.LoggerFactory
 
 
 enum CitationStyle:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationMaker.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationMaker.scala
@@ -2,33 +2,23 @@ package se.lu.nateko.cp.meta.services.citation
 
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.SKOS
-import se.lu.nateko.cp.doi.Doi
-import se.lu.nateko.cp.doi.DoiMeta
+import org.eclipse.rdf4j.model.vocabulary.{RDFS, SKOS}
+import org.slf4j.LoggerFactory
+import se.lu.nateko.cp.doi.{Doi, DoiMeta}
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.MetaCoreConfig
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.metaflow.icos.EtcMetaSource.toCETnoon
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.parseCommaSepList
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.utils.{Validated, parseCommaSepList}
 
 import java.net.URI
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-
-import org.slf4j.LoggerFactory
+import java.time.{Duration, Instant, ZoneId, ZonedDateTime}
+import scala.util.{Failure, Success, Try}
 
 private class CitationInfo(
 	val pidUrl: Option[String],

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationProvider.scala
@@ -1,37 +1,25 @@
 package se.lu.nateko.cp.meta.services.citation
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.stream.Materializer
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Resource
 import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, Resource}
 import org.eclipse.rdf4j.repository.sail.SailRepository
 import org.eclipse.rdf4j.sail.Sail
 import se.lu.nateko.cp.doi.Doi
-import se.lu.nateko.cp.meta.CpmetaConfig
-import se.lu.nateko.cp.meta.MetaDb
-import se.lu.nateko.cp.meta.api.HandleNetClient
-import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
-import se.lu.nateko.cp.meta.core.data.CitableItem
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.EnvriResolver
-import se.lu.nateko.cp.meta.core.data.Licence
-import se.lu.nateko.cp.meta.core.data.References
-import se.lu.nateko.cp.meta.core.data.StaticCollection
-import se.lu.nateko.cp.meta.core.data.StaticObject
-import se.lu.nateko.cp.meta.core.data.collectionPrefix
-import se.lu.nateko.cp.meta.core.data.objectPrefix
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens}
+import se.lu.nateko.cp.meta.core.data.{CitableItem, EnvriConfigs, EnvriResolver, Licence, References, StaticCollection, StaticObject, collectionPrefix, objectPrefix}
+import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.{CpmetaConfig, MetaDb}
+
 import CitationClient.CitationCache
 import CitationClient.DoiCache
-import akka.event.Logging
 
 
 object CitationProvider:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/FileService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/FileService.scala
@@ -1,21 +1,17 @@
 package se.lu.nateko.cp.meta.services.labeling
 
 import akka.http.scaladsl.model.HttpEntity.Chunked
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.MediaTypes
-import akka.http.scaladsl.model.Multipart
+import akka.http.scaladsl.model.{HttpResponse, MediaTypes, Multipart}
 import org.eclipse.rdf4j.model.IRI
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.MetadataException
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 
 trait FileService:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/FileService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/FileService.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.{HttpResponse, MediaTypes, Multipart}
 import org.eclipse.rdf4j.model.IRI
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.services.MetadataException
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/LabelingDb.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/LabelingDb.scala
@@ -1,9 +1,7 @@
 package se.lu.nateko.cp.meta.services.labeling
 
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.LoggingInstanceServer
 import org.eclipse.rdf4j.model.Statement
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, LoggingInstanceServer, TriplestoreConnection}
 
 object LabelingDb:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/LifecycleService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/LifecycleService.scala
@@ -1,22 +1,16 @@
 package se.lu.nateko.cp.meta.services.labeling
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.model.{IRI, Statement}
+import org.slf4j.LoggerFactory
 import play.twirl.api.Html
-import se.lu.nateko.cp.cpauth.core.EmailSender
-import se.lu.nateko.cp.cpauth.core.UserId
+import se.lu.nateko.cp.cpauth.core.{EmailSender, UserId}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.IllegalLabelingStatusException
-import se.lu.nateko.cp.meta.services.UnauthorizedStationUpdateException
+import se.lu.nateko.cp.meta.services.{IllegalLabelingStatusException, UnauthorizedStationUpdateException}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.net.URI
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import org.slf4j.LoggerFactory
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 trait LifecycleService:
 	self: StationLabelingService =>

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/StationInfoService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/StationInfoService.scala
@@ -1,15 +1,12 @@
 package se.lu.nateko.cp.meta.services.labeling
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.model.{IRI, Literal, Statement}
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.core.data.DataTheme
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.onto.InstOnto
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import spray.json.JsObject
-import spray.json.JsString
+import spray.json.{JsObject, JsString}
 
 import java.net.URI
 import java.time.Instant

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/StationInfoService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/StationInfoService.scala
@@ -2,7 +2,6 @@ package se.lu.nateko.cp.meta.services.labeling
 
 import org.eclipse.rdf4j.model.{IRI, Literal, Statement}
 import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.meta.core.data.DataTheme
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.onto.InstOnto
 import se.lu.nateko.cp.meta.utils.rdf4j.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/StationLabelingService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/StationLabelingService.scala
@@ -1,17 +1,11 @@
 package se.lu.nateko.cp.meta.services.labeling
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.LabelingServiceConfig
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.onto.InstOnto
-import se.lu.nateko.cp.meta.onto.Onto
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.FileStorageService
-import se.lu.nateko.cp.meta.services.UnauthorizedStationUpdateException
-import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.onto.{InstOnto, Onto}
+import se.lu.nateko.cp.meta.services.{CpmetaVocab, FileStorageService, MetadataException, UnauthorizedStationUpdateException}
 
 
 class StationLabelingService(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/UserInfoService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/UserInfoService.scala
@@ -1,14 +1,13 @@
 package se.lu.nateko.cp.meta.services.labeling
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
 import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, Literal}
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.LabelingUserDto
 import se.lu.nateko.cp.meta.services.UnauthorizedUserInfoUpdateException
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import java.net.{URI => JavaURI}
+import java.net.URI as JavaURI
 import scala.util.Using
 
 trait UserInfoService:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/labeling/Vocabs.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/labeling/Vocabs.scala
@@ -1,8 +1,6 @@
 package se.lu.nateko.cp.meta.services.labeling
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
-
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.meta.api.CustomVocab
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/InstanceServerSerializer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/InstanceServerSerializer.scala
@@ -1,32 +1,21 @@
 package se.lu.nateko.cp.meta.services.linkeddata
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-
-import org.eclipse.rdf4j.model.Namespace
-import org.eclipse.rdf4j.model.Statement
+import akka.http.scaladsl.marshalling.{Marshaller, Marshalling, ToResponseMarshaller}
+import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpCharsets, HttpEntity, HttpResponse, MediaType, MediaTypes}
+import akka.stream.StreamDetachedException
+import akka.stream.scaladsl.StreamConverters
 import org.eclipse.rdf4j.model.impl.SimpleNamespace
 import org.eclipse.rdf4j.model.vocabulary.{ OWL, RDF, RDFS, XSD }
+import org.eclipse.rdf4j.model.{Namespace, Statement}
 import org.eclipse.rdf4j.rio.RDFWriterFactory
 import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriterFactory
 import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory
-
-import akka.http.scaladsl.marshalling.Marshaller
-import akka.http.scaladsl.marshalling.Marshalling
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.model.ContentType
-import akka.http.scaladsl.model.ContentTypes
-import akka.http.scaladsl.model.HttpCharsets
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.MediaType
-import akka.http.scaladsl.model.MediaTypes
-import akka.stream.scaladsl.StreamConverters
 import se.lu.nateko.cp.meta.api.CloseableIterator
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import scala.util.Using
+
 import java.io.IOException
-import akka.stream.StreamDetachedException
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Using
 
 object InstanceServerSerializer {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
@@ -296,8 +296,6 @@ class Rdf4jUriSerializer(
 	private def customJson[T : JsonWriter](fetchDto: () => Validated[T]): Marshalling[HttpResponse] =
 		WithFixedContentType(ContentTypes.`application/json`, () => PageContentMarshalling.getJson(fetchDto()))
 
-	import PageContentMarshalling.ErrorList
-
 	private def defaultHtml(uri: Uri): Marshalling[HttpResponse] =
 		WithOpenCharset(MediaTypes.`text/html`, getDefaultHtml(uri))
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
@@ -1,54 +1,36 @@
 package se.lu.nateko.cp.meta.services.linkeddata
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.marshalling.Marshaller
-import akka.http.scaladsl.marshalling.Marshalling
-import akka.http.scaladsl.marshalling.Marshalling.WithFixedContentType
-import akka.http.scaladsl.marshalling.Marshalling.WithOpenCharset
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.model.Uri.Path.Empty
-import akka.http.scaladsl.model.Uri.Path.Segment
-import akka.http.scaladsl.model.Uri.Path.Slash
+import akka.http.scaladsl.marshalling.Marshalling.{WithFixedContentType, WithOpenCharset}
+import akka.http.scaladsl.marshalling.{Marshaller, Marshalling, ToResponseMarshaller}
 import akka.http.scaladsl.model.*
+import akka.http.scaladsl.model.Uri.Path.{Empty, Segment, Slash}
 import akka.stream.Materializer
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.query.BindingSet
-import org.eclipse.rdf4j.query.QueryLanguage
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import org.eclipse.rdf4j.model.{IRI, Literal, Statement, ValueFactory}
+import org.eclipse.rdf4j.query.{BindingSet, QueryLanguage}
 import org.eclipse.rdf4j.repository.Repository
 import play.twirl.api.Html
-import se.lu.nateko.cp.meta.CpmetaConfig
-import se.lu.nateko.cp.meta.api
 import se.lu.nateko.cp.meta.api.*
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.JsonSupport.given
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.services.citation.CitationMaker
-import se.lu.nateko.cp.meta.services.citation.PlainDoiCiter
-import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling
+import se.lu.nateko.cp.meta.core.data.JsonSupport.given
+import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.citation.{CitationMaker, PlainDoiCiter}
 import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling.ErrorList
-import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
+import se.lu.nateko.cp.meta.services.upload.{PageContentMarshalling, StaticObjectReader}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.views.ResourceViewInfo
 import se.lu.nateko.cp.meta.views.ResourceViewInfo.PropValue
+import se.lu.nateko.cp.meta.{CpmetaConfig, api}
 import spray.json.JsonWriter
 
-import java.net.{URI => JavaUri}
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Try
-import scala.util.Using
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
+import java.net.URI as JavaUri
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Try, Using}
 
 
 trait UriSerializer {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
@@ -1,36 +1,54 @@
 package se.lu.nateko.cp.meta.services.linkeddata
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.marshalling.Marshalling.{WithFixedContentType, WithOpenCharset}
-import akka.http.scaladsl.marshalling.{Marshaller, Marshalling, ToResponseMarshaller}
+import akka.http.scaladsl.marshalling.Marshaller
+import akka.http.scaladsl.marshalling.Marshalling
+import akka.http.scaladsl.marshalling.Marshalling.WithFixedContentType
+import akka.http.scaladsl.marshalling.Marshalling.WithOpenCharset
+import akka.http.scaladsl.marshalling.ToResponseMarshaller
+import akka.http.scaladsl.model.Uri.Path.Empty
+import akka.http.scaladsl.model.Uri.Path.Segment
+import akka.http.scaladsl.model.Uri.Path.Slash
 import akka.http.scaladsl.model.*
-import akka.http.scaladsl.model.Uri.Path.{Empty, Segment, Slash}
 import akka.stream.Materializer
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
-import org.eclipse.rdf4j.model.{IRI, Literal, Statement, ValueFactory}
-import org.eclipse.rdf4j.query.{BindingSet, QueryLanguage}
+import org.eclipse.rdf4j.model.IRI
+import org.eclipse.rdf4j.model.Literal
+import org.eclipse.rdf4j.model.Statement
+import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.vocabulary.RDFS
+import org.eclipse.rdf4j.query.BindingSet
+import org.eclipse.rdf4j.query.QueryLanguage
 import org.eclipse.rdf4j.repository.Repository
 import play.twirl.api.Html
+import se.lu.nateko.cp.meta.CpmetaConfig
+import se.lu.nateko.cp.meta.api
 import se.lu.nateko.cp.meta.api.*
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.meta.instanceserver.{Rdf4jInstanceServer, TriplestoreConnection}
-import se.lu.nateko.cp.meta.services.citation.{CitationMaker, PlainDoiCiter}
+import se.lu.nateko.cp.meta.core.data.*
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.services.CpVocab
+import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.services.citation.CitationMaker
+import se.lu.nateko.cp.meta.services.citation.PlainDoiCiter
+import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling
 import se.lu.nateko.cp.meta.services.upload.PageContentMarshalling.ErrorList
-import se.lu.nateko.cp.meta.services.upload.{PageContentMarshalling, StaticObjectReader}
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException}
+import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.views.ResourceViewInfo
 import se.lu.nateko.cp.meta.views.ResourceViewInfo.PropValue
-import se.lu.nateko.cp.meta.{CpmetaConfig, api}
 import spray.json.JsonWriter
 
-import java.net.URI as JavaUri
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Try, Using}
+import java.net.{URI => JavaUri}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.util.Try
+import scala.util.Using
+import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
 
 
 trait UriSerializer {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DataCite.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DataCite.scala
@@ -2,7 +2,7 @@ package se.lu.nateko.cp.meta.services.metaexport
 
 import se.lu.nateko.cp.doi.meta.*
 import se.lu.nateko.cp.doi.{CoolDoi, Doi, DoiMeta}
-import se.lu.nateko.cp.meta.core.data.{Agent, DataObject, DocObject, FunderIdType, Funding, Organization, Person, PlainStaticObject, StaticCollection, StaticObject}
+import se.lu.nateko.cp.meta.core.data.{Agent, DataObject, DocObject, FunderIdType, Funding, Organization, Person, StaticCollection, StaticObject}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.utils.Validated
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DataCite.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DataCite.scala
@@ -1,24 +1,12 @@
 package se.lu.nateko.cp.meta.services.metaexport
 
-import se.lu.nateko.cp.doi.CoolDoi
-import se.lu.nateko.cp.doi.Doi
-import se.lu.nateko.cp.doi.DoiMeta
 import se.lu.nateko.cp.doi.meta.*
-import se.lu.nateko.cp.meta.core.data.Agent
-import se.lu.nateko.cp.meta.core.data.DataObject
-import se.lu.nateko.cp.meta.core.data.DocObject
-import se.lu.nateko.cp.meta.core.data.FunderIdType
-import se.lu.nateko.cp.meta.core.data.Funding
-import se.lu.nateko.cp.meta.core.data.Organization
-import se.lu.nateko.cp.meta.core.data.Person
-import se.lu.nateko.cp.meta.core.data.PlainStaticObject
-import se.lu.nateko.cp.meta.core.data.StaticCollection
-import se.lu.nateko.cp.meta.core.data.StaticObject
+import se.lu.nateko.cp.doi.{CoolDoi, Doi, DoiMeta}
+import se.lu.nateko.cp.meta.core.data.{Agent, DataObject, DocObject, FunderIdType, Funding, Organization, Person, PlainStaticObject, StaticCollection, StaticObject}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.utils.Validated
 
-import java.time.Instant
-import java.time.Year
+import java.time.{Instant, Year}
 
 
 class DataCite(doiMaker: String => Doi, fetchCollObjectsRecursively: StaticCollection => Validated[Seq[StaticObject]]):

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DoiGeoCovConverter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DoiGeoCovConverter.scala
@@ -1,7 +1,17 @@
 package se.lu.nateko.cp.meta.services.metaexport
 
-import se.lu.nateko.cp.doi.meta.{GeoLocation, *}
-import se.lu.nateko.cp.meta.core.data.{Circle, FeatureCollection, FeatureWithGeoJson, GeoFeature, GeoTrack, LatLonBox, Pin, Polygon, Position}
+import se.lu.nateko.cp.doi.meta.{GeoLocation, GeoLocationPoint, Longitude, Latitude, GeoLocationBox}
+import se.lu.nateko.cp.meta.core.data.{
+	Circle,
+	FeatureCollection,
+	FeatureWithGeoJson,
+	GeoFeature,
+	GeoTrack,
+	LatLonBox,
+	Pin,
+	Polygon,
+	Position
+}
 import se.lu.nateko.cp.meta.services.upload.geocov.GeoCovMerger.circleToBox
 
 object DoiGeoCovConverter:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DoiGeoCovConverter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/DoiGeoCovConverter.scala
@@ -1,17 +1,8 @@
 package se.lu.nateko.cp.meta.services.metaexport
 
-import se.lu.nateko.cp.doi.meta.*
-import se.lu.nateko.cp.doi.meta.GeoLocation
-import se.lu.nateko.cp.meta.core.data.Circle
-import se.lu.nateko.cp.meta.core.data.FeatureCollection
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import se.lu.nateko.cp.meta.core.data.GeoTrack
-import se.lu.nateko.cp.meta.core.data.LatLonBox
-import se.lu.nateko.cp.meta.core.data.Pin
-import se.lu.nateko.cp.meta.core.data.Polygon
-import se.lu.nateko.cp.meta.core.data.Position
+import se.lu.nateko.cp.doi.meta.{GeoLocation, *}
+import se.lu.nateko.cp.meta.core.data.{Circle, FeatureCollection, FeatureWithGeoJson, GeoFeature, GeoTrack, LatLonBox, Pin, Polygon, Position}
 import se.lu.nateko.cp.meta.services.upload.geocov.GeoCovMerger.circleToBox
-import se.lu.nateko.cp.meta.core.data.FeatureWithGeoJson
 
 object DoiGeoCovConverter:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/Inspire.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/Inspire.scala
@@ -5,7 +5,6 @@ import se.lu.nateko.cp.meta.services.CpVocab
 import se.lu.nateko.cp.meta.utils.rdf4j.===
 
 import java.time.Instant
-import scala.quoted.{Expr, Quotes}
 
 
 object Inspire{

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/Inspire.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/Inspire.scala
@@ -1,12 +1,11 @@
 package se.lu.nateko.cp.meta.services.metaexport
 
-import se.lu.nateko.cp.meta.core.data.DataObject
-import java.time.Instant
-import scala.quoted.Expr
-import scala.quoted.Quotes
+import se.lu.nateko.cp.meta.core.data.{DataObject, TimeInterval}
 import se.lu.nateko.cp.meta.services.CpVocab
 import se.lu.nateko.cp.meta.utils.rdf4j.===
-import se.lu.nateko.cp.meta.core.data.TimeInterval
+
+import java.time.Instant
+import scala.quoted.{Expr, Quotes}
 
 
 object Inspire{

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala
@@ -1,26 +1,23 @@
 package se.lu.nateko.cp.meta.services.metaexport
 
 import akka.http.scaladsl.server.directives.ContentTypeResolver
+import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
-import se.lu.nateko.cp.doi.{meta => doi}
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
+import se.lu.nateko.cp.doi.meta as doi
+import se.lu.nateko.cp.doi.meta.{GenericName, PersonalName}
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
 import se.lu.nateko.cp.meta.core.HandleProxiesConfig
 import se.lu.nateko.cp.meta.core.data.*
+import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.json.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.views.LandingPageHelpers.doiAgentUri
 import spray.json.*
-import se.lu.nateko.cp.meta.utils.*
 
 import java.net.URI
+import java.time.{LocalDate, ZoneOffset}
 
-import doi.DescriptionType.{Abstract => DoiAbstract}
-import java.time.LocalDate
-import java.time.ZoneOffset
-import se.lu.nateko.cp.doi.meta.PersonalName
-import se.lu.nateko.cp.doi.meta.GenericName
-import eu.icoscp.envri.Envri
+import doi.DescriptionType.Abstract as DoiAbstract
 
 object SchemaOrg:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/QueryEvaluator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/QueryEvaluator.scala
@@ -1,17 +1,13 @@
 package se.lu.nateko.cp.meta.services.sparql
 
 import akka.Done
-import org.eclipse.rdf4j.query.GraphQuery
-import org.eclipse.rdf4j.query.Query
-import org.eclipse.rdf4j.query.QueryResults
-import org.eclipse.rdf4j.query.TupleQuery
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory
+import org.eclipse.rdf4j.query.{GraphQuery, Query, QueryResults, TupleQuery}
 import org.eclipse.rdf4j.rio.RDFWriterFactory
 
 import java.io.OutputStream
 import java.lang.AutoCloseable
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 trait QueryEvaluator[Q <: Query] {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/QuotaManager.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/QuotaManager.scala
@@ -3,9 +3,9 @@ package se.lu.nateko.cp.meta.services.sparql
 import se.lu.nateko.cp.meta.SparqlServerConfig
 
 import java.time.Instant
-import java.time.temporal.{ChronoUnit, TemporalUnit}
+import java.time.temporal.ChronoUnit
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.{ConcurrentLinkedQueue, Executor, RejectedExecutionException}
+import java.util.concurrent.{ConcurrentLinkedQueue, Executor}
 import scala.collection.concurrent.TrieMap
 
 class QuotaManager(config: SparqlServerConfig, executor: Executor)(implicit val now: () => Instant):

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/QuotaManager.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/QuotaManager.scala
@@ -1,14 +1,12 @@
 package se.lu.nateko.cp.meta.services.sparql
 
 import se.lu.nateko.cp.meta.SparqlServerConfig
+
 import java.time.Instant
-import scala.collection.concurrent.TrieMap
+import java.time.temporal.{ChronoUnit, TemporalUnit}
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.Executor
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.RejectedExecutionException
-import java.time.temporal.TemporalUnit
-import java.time.temporal.ChronoUnit
+import java.util.concurrent.{ConcurrentLinkedQueue, Executor, RejectedExecutionException}
+import scala.collection.concurrent.TrieMap
 
 class QuotaManager(config: SparqlServerConfig, executor: Executor)(implicit val now: () => Instant):
 	import QuotaManager.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/Rdf4jSparqlServer.scala
@@ -1,55 +1,33 @@
 package se.lu.nateko.cp.meta.services.sparql
 
-import akka.Done
-import akka.NotUsed
-import akka.http.scaladsl.marshalling.Marshaller
-import akka.http.scaladsl.marshalling.Marshalling
-import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.model.ContentType
-import akka.http.scaladsl.model.ContentTypes
-import akka.http.scaladsl.model.HttpCharsets
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.MediaType
-import akka.http.scaladsl.model.MediaTypes
-import akka.http.scaladsl.model.StatusCode
-import akka.http.scaladsl.model.StatusCodes
-import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.StreamConverters
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.http.scaladsl.marshalling.{Marshaller, Marshalling, ToResponseMarshaller}
+import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpCharsets, HttpEntity, HttpResponse, MediaType, MediaTypes, StatusCode, StatusCodes}
+import akka.stream.scaladsl.{Sink, Source, StreamConverters}
 import akka.util.ByteString
-import org.eclipse.rdf4j.query.GraphQuery
-import org.eclipse.rdf4j.query.MalformedQueryException
-import org.eclipse.rdf4j.query.Query
-import org.eclipse.rdf4j.query.TupleQuery
-import org.eclipse.rdf4j.query.parser.ParsedBooleanQuery
-import org.eclipse.rdf4j.query.parser.ParsedGraphQuery
-import org.eclipse.rdf4j.query.parser.ParsedTupleQuery
+import akka.{Done, NotUsed}
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser
+import org.eclipse.rdf4j.query.parser.{ParsedBooleanQuery, ParsedGraphQuery, ParsedTupleQuery}
 import org.eclipse.rdf4j.query.resultio.TupleQueryResultWriterFactory
 import org.eclipse.rdf4j.query.resultio.sparqljson.SPARQLResultsJSONWriterFactory
 import org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLWriterFactory
 import org.eclipse.rdf4j.query.resultio.text.csv.SPARQLResultsCSVWriterFactory
 import org.eclipse.rdf4j.query.resultio.text.tsv.SPARQLResultsTSVWriterFactory
+import org.eclipse.rdf4j.query.{GraphQuery, MalformedQueryException, Query, TupleQuery}
 import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.rio.RDFWriterFactory
 import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriterFactory
 import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory
 import se.lu.nateko.cp.meta.SparqlServerConfig
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlServer
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlServer}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
 
 import java.time.Instant
-import java.util.concurrent.CancellationException
-import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
+import java.util.concurrent.{CancellationException, Executors}
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
-import akka.actor.ActorSystem
-import akka.event.Logging
 
 
 class Rdf4jSparqlServer(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/FileSizeHierarchicalBitmap.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/FileSizeHierarchicalBitmap.scala
@@ -3,7 +3,6 @@ package se.lu.nateko.cp.meta.services.sparql.index
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
 import se.lu.nateko.cp.meta.services.sparql.magic.index.ObjEntry
 
-import java.time.Instant
 import scala.collection.IndexedSeq
 
 /**

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/FileSizeHierarchicalBitmap.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/FileSizeHierarchicalBitmap.scala
@@ -1,8 +1,9 @@
 package se.lu.nateko.cp.meta.services.sparql.index
 
-import java.time.Instant
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
 import se.lu.nateko.cp.meta.services.sparql.magic.index.ObjEntry
+
+import java.time.Instant
 import scala.collection.IndexedSeq
 
 /**

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/SamplingHeightHierarchicalBitmap.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/SamplingHeightHierarchicalBitmap.scala
@@ -3,8 +3,6 @@ package se.lu.nateko.cp.meta.services.sparql.index
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
 import se.lu.nateko.cp.meta.services.sparql.magic.index.ObjEntry
 
-import java.time.Instant
-import scala.annotation.tailrec
 import scala.collection.IndexedSeq
 
 /**

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/SamplingHeightHierarchicalBitmap.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/SamplingHeightHierarchicalBitmap.scala
@@ -1,9 +1,10 @@
 package se.lu.nateko.cp.meta.services.sparql.index
 
-import java.time.Instant
-import scala.annotation.tailrec
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
 import se.lu.nateko.cp.meta.services.sparql.magic.index.ObjEntry
+
+import java.time.Instant
+import scala.annotation.tailrec
 import scala.collection.IndexedSeq
 
 /**

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/StringHierarchicalBitmap.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/StringHierarchicalBitmap.scala
@@ -1,7 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.index
 
-import scala.collection.IndexedSeq
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
+
+import scala.collection.IndexedSeq
 
 
 object StringHierarchicalBitmap:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/StringHierarchicalBitmap.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/index/StringHierarchicalBitmap.scala
@@ -2,8 +2,6 @@ package se.lu.nateko.cp.meta.services.sparql.index
 
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
 
-import scala.collection.IndexedSeq
-
 
 object StringHierarchicalBitmap:
 	import HierarchicalBitmap.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpEnrichedTripleSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpEnrichedTripleSource.scala
@@ -1,14 +1,10 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource
 import org.eclipse.rdf4j.common.iteration.CloseableIteration
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Resource
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
+import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource
 
 import StatementsEnricher.StatIter
-import org.eclipse.rdf4j.model.ValueFactory
 
 class CpEnrichedTripleSource(base: TripleSource, enricher: StatementsEnricher) extends TripleSource{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpEnrichedTripleSource.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpEnrichedTripleSource.scala
@@ -1,7 +1,5 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
-
-import org.eclipse.rdf4j.common.iteration.CloseableIteration
-import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.model.{IRI, Resource, Value, ValueFactory}
 import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource
 
 import StatementsEnricher.StatIter

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
@@ -1,24 +1,18 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.model.{IRI, Value, ValueFactory}
 import org.eclipse.rdf4j.sail.Sail
-import org.roaringbitmap.buffer.BufferFastAggregation
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap
-import org.roaringbitmap.buffer.MutableRoaringBitmap
+import org.roaringbitmap.buffer.{BufferFastAggregation, ImmutableRoaringBitmap, MutableRoaringBitmap}
+import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.instanceserver.{RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.sparql.index.*
+import se.lu.nateko.cp.meta.services.sparql.magic.index.{IndexData, StatEntry, emptyBitmap}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.async.ReadWriteLocking
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-
 
 import java.io.Serializable
 import java.time.Instant
@@ -26,11 +20,9 @@ import java.util.ArrayList
 import java.util.concurrent.ArrayBlockingQueue
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-import scala.util.Failure
-import scala.util.Success
+import scala.util.{Failure, Success}
+
 import CpIndex.*
-import org.slf4j.LoggerFactory
-import se.lu.nateko.cp.meta.services.sparql.magic.index.{IndexData, StatEntry, emptyBitmap}
 
 trait ObjSpecific{
 	def hash: Sha256Sum

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpNotifyingSail.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpNotifyingSail.scala
@@ -8,13 +8,14 @@ import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient
 import org.eclipse.rdf4j.sail.helpers.{NotifyingSailConnectionWrapper, NotifyingSailWrapper}
 import org.eclipse.rdf4j.sail.{NotifyingSail, NotifyingSailConnection, SailConnectionListener}
+import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.services.citation.{CitationClient, CitationProvider}
 import se.lu.nateko.cp.meta.utils.async.ok
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.reflect.Selectable.reflectiveSelectable
 import scala.util.{Failure, Success}
-import org.slf4j.LoggerFactory
+
 import index.IndexData
 
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpQueryOptimizerPipeline.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpQueryOptimizerPipeline.scala
@@ -1,13 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy
-import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizer
-import org.eclipse.rdf4j.query.algebra.evaluation.QueryOptimizerPipeline
-import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics
-import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.OrderLimitOptimizer
-import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.QueryJoinOptimizer
-import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.StandardQueryOptimizerPipeline
+import org.eclipse.rdf4j.query.algebra.evaluation.optimizer.{OrderLimitOptimizer, QueryJoinOptimizer, StandardQueryOptimizerPipeline}
+import org.eclipse.rdf4j.query.algebra.evaluation.{EvaluationStrategy, QueryOptimizer, QueryOptimizerPipeline, TripleSource}
 
 class CpQueryOptimizerPipeline(
 	strat: EvaluationStrategy,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoEventProducer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoEventProducer.scala
@@ -1,14 +1,13 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
 import org.eclipse.rdf4j.model.IRI
-import org.locationtech.jts.geom.Coordinate
-import org.locationtech.jts.geom.GeometryCollection
+import org.locationtech.jts.geom.{Coordinate, GeometryCollection}
 import org.locationtech.jts.io.geojson.GeoJsonReader
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
 import se.lu.nateko.cp.meta.core.data.DatasetType
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
-import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.utils.Validated
 
 class GeoEventProducer(cpIndex: CpIndex, metaVocab: CpmetaVocab, geoLookup: GeoLookup):
 	private val geoJsonReader = GeoJsonReader()

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoIndex.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoIndex.scala
@@ -1,12 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
 import org.locationtech.jts.algorithm.hull.ConcaveHull
-import org.locationtech.jts.geom.Envelope
-import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryCollection
-import org.locationtech.jts.geom.GeometryFactory
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap
-import org.roaringbitmap.buffer.MutableRoaringBitmap
+import org.locationtech.jts.geom.{Envelope, Geometry, GeometryCollection, GeometryFactory}
+import org.roaringbitmap.buffer.{ImmutableRoaringBitmap, MutableRoaringBitmap}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoIndexProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoIndexProvider.scala
@@ -2,17 +2,15 @@ package se.lu.nateko.cp.meta.services.sparql.magic
 
 import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.sail.Sail
+import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.getStatements
-import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
-import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement
-import se.lu.nateko.cp.meta.utils.rdf4j.accessEagerly
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Using
 import se.lu.nateko.cp.meta.services.CpmetaVocab
-import org.slf4j.LoggerFactory
+import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
+import se.lu.nateko.cp.meta.utils.rdf4j.{Rdf4jStatement, accessEagerly}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Using
 
 class GeoIndexProvider(using ExecutionContext):
 	private val log = LoggerFactory.getLogger(getClass())

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoLookup.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/GeoLookup.scala
@@ -2,14 +2,11 @@ package se.lu.nateko.cp.meta.services.sparql.magic
 
 import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.locationtech.jts.geom.Coordinate
-import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.{Coordinate, Geometry}
 import org.locationtech.jts.io.geojson.GeoJsonReader
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
 import se.lu.nateko.cp.meta.core.crypto.Md5Sum
-import se.lu.nateko.cp.meta.core.data.DatasetType
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import se.lu.nateko.cp.meta.core.data.GeoJson
+import se.lu.nateko.cp.meta.core.data.{DatasetType, GeoFeature, GeoJson}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
 import se.lu.nateko.cp.meta.services.upload.StaticObjectReader
 import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
@@ -40,6 +40,7 @@ import se.lu.nateko.cp.meta.services.sparql.magic.index.{
 }
 import se.lu.nateko.cp.meta.utils.async.throttle
 import se.lu.nateko.cp.meta.utils.rdf4j.{===, Rdf4jStatement, accessEagerly}
+
 import java.io.{FileInputStream, FileOutputStream, InputStream, OutputStream}
 import java.nio.file.{Files, Paths}
 import java.util.zip.{GZIPInputStream, GZIPOutputStream}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/ReadonlyConnectionWrapper.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/ReadonlyConnectionWrapper.scala
@@ -1,11 +1,9 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
+import org.eclipse.rdf4j.model.{IRI, Resource, Value}
 import org.eclipse.rdf4j.sail.helpers.NotifyingSailConnectionWrapper
-import org.eclipse.rdf4j.sail.NotifyingSailConnection
-import org.eclipse.rdf4j.sail.UpdateContext
-import org.eclipse.rdf4j.model.Resource
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
+import org.eclipse.rdf4j.sail.{NotifyingSailConnection, UpdateContext}
+
 import scala.util.control.NoStackTrace
 
 class ReadonlyConnectionWrapper(conn: NotifyingSailConnection, errorMessage: String) extends NotifyingSailConnectionWrapper(conn){

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/SimpleTupleFunctionExprEnricher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/SimpleTupleFunctionExprEnricher.scala
@@ -1,10 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.query.algebra.StatementPattern
-import org.eclipse.rdf4j.query.algebra.TupleFunctionCall
-import org.eclipse.rdf4j.query.algebra.ValueConstant
 import org.eclipse.rdf4j.query.algebra.evaluation.function.TupleFunction
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor
+import org.eclipse.rdf4j.query.algebra.{StatementPattern, TupleFunctionCall, ValueConstant}
 import org.eclipse.rdf4j.sail.SailException
 
 class SimpleTupleFunctionExprEnricher(funcs: Map[String, TupleFunction]) extends AbstractQueryModelVisitor[SailException]{

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/StatementsEnricher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/StatementsEnricher.scala
@@ -5,7 +5,6 @@ import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
 import org.eclipse.rdf4j.repository.sparql.federation.CollectionIteration
 import org.eclipse.rdf4j.sail.SailException
 import se.lu.nateko.cp.meta.core.data.References
-import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.citation.CitationProvider
 import se.lu.nateko.cp.meta.utils.rdf4j.{createStringLiteral, toRdf}
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/StatementsEnricher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/StatementsEnricher.scala
@@ -1,21 +1,13 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.common.iteration.CloseableIteration
-import org.eclipse.rdf4j.common.iteration.EmptyIteration
-import org.eclipse.rdf4j.common.iteration.SingletonIteration
-import org.eclipse.rdf4j.common.iteration.UnionIteration
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Resource
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.common.iteration.{CloseableIteration, EmptyIteration, SingletonIteration, UnionIteration}
+import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
 import org.eclipse.rdf4j.repository.sparql.federation.CollectionIteration
 import org.eclipse.rdf4j.sail.SailException
 import se.lu.nateko.cp.meta.core.data.References
 import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.citation.CitationProvider
-import se.lu.nateko.cp.meta.utils.rdf4j.createStringLiteral
-import se.lu.nateko.cp.meta.utils.rdf4j.toRdf
+import se.lu.nateko.cp.meta.utils.rdf4j.{createStringLiteral, toRdf}
 
 import java.util.Arrays
 import scala.collection.immutable.SeqMap

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/StorageSail.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/StorageSail.scala
@@ -1,14 +1,12 @@
 package se.lu.nateko.cp.meta.services.sparql.magic
 
-import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig
 import org.eclipse.rdf4j.sail.lmdb.LmdbStore
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore
-import se.lu.nateko.cp.meta.RdfStorageConfig
-import java.nio.file.FileVisitOption
-import java.nio.file.Files
-import java.nio.file.Paths
 import org.slf4j.LoggerFactory
+import se.lu.nateko.cp.meta.RdfStorageConfig
+
+import java.nio.file.{FileVisitOption, Files, Paths}
 
 object StorageSail:
 	private val log = LoggerFactory.getLogger(getClass())

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DanglingCleanup.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DanglingCleanup.scala
@@ -1,9 +1,7 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import org.eclipse.rdf4j.query.algebra.StatementPattern
-import org.eclipse.rdf4j.query.algebra.SingletonSet
-import org.eclipse.rdf4j.query.algebra.QueryModelNode
 import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor
+import org.eclipse.rdf4j.query.algebra.{QueryModelNode, SingletonSet, StatementPattern}
 
 object DanglingCleanup{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DataObjectFetchNode.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DataObjectFetchNode.scala
@@ -1,10 +1,10 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import scala.jdk.CollectionConverters.SeqHasAsJava
 import org.eclipse.rdf4j.query.algebra.*
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics
-import se.lu.nateko.cp.meta.services.sparql.index.DataObjectFetch
-import se.lu.nateko.cp.meta.services.sparql.index.Property
+import se.lu.nateko.cp.meta.services.sparql.index.{DataObjectFetch, Property}
+
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class DataObjectFetchNode(
 	val fetchRequest: DataObjectFetch,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPattern.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPattern.scala
@@ -1,7 +1,6 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
+import org.eclipse.rdf4j.model.{IRI, Value}
 import org.eclipse.rdf4j.query.algebra.*
 
 /**

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
@@ -2,11 +2,10 @@ package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
 import org.eclipse.rdf4j.model.vocabulary.GEO
 import org.eclipse.rdf4j.model.{IRI, Literal, Value}
-import org.eclipse.rdf4j.query.algebra.{BindingSetAssignment, Exists, Extension, Not, QueryModelNode, SingletonSet, StatementPattern, TupleExpr, Union, ValueExpr}
+import org.eclipse.rdf4j.query.algebra.{Extension, QueryModelNode, StatementPattern, TupleExpr}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.sparql.index
 import se.lu.nateko.cp.meta.services.sparql.index.{Exists as _, *}
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchNode
 import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchPatternSearch.GroupPattern
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
@@ -5,7 +5,7 @@ import org.eclipse.rdf4j.model.{IRI, Literal, Value}
 import org.eclipse.rdf4j.query.algebra.{Extension, QueryModelNode, StatementPattern, TupleExpr}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.sparql.index
-import se.lu.nateko.cp.meta.services.sparql.index.{Exists as _, *}
+import se.lu.nateko.cp.meta.services.sparql.index.*
 import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchPatternSearch.GroupPattern
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
@@ -1,27 +1,16 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.query.algebra.BindingSetAssignment
-import org.eclipse.rdf4j.query.algebra.Exists
-import org.eclipse.rdf4j.query.algebra.Extension
-import org.eclipse.rdf4j.query.algebra.Not
-import org.eclipse.rdf4j.query.algebra.QueryModelNode
-import org.eclipse.rdf4j.query.algebra.SingletonSet
-import org.eclipse.rdf4j.query.algebra.StatementPattern
-import org.eclipse.rdf4j.query.algebra.TupleExpr
-import org.eclipse.rdf4j.query.algebra.Union
-import org.eclipse.rdf4j.query.algebra.ValueExpr
+import org.eclipse.rdf4j.model.vocabulary.GEO
+import org.eclipse.rdf4j.model.{IRI, Literal, Value}
+import org.eclipse.rdf4j.query.algebra.{BindingSetAssignment, Exists, Extension, Not, QueryModelNode, SingletonSet, StatementPattern, TupleExpr, Union, ValueExpr}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.sparql.index
-import se.lu.nateko.cp.meta.services.sparql.index.{Exists => _, *}
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchPatternSearch.GroupPattern
+import se.lu.nateko.cp.meta.services.sparql.index.{Exists as _, *}
 import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchNode
+import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchPatternSearch.GroupPattern
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import DofPatternFusion.*
-import org.eclipse.rdf4j.model.vocabulary.GEO
 
 sealed trait FusionPattern
 case class DobjStatFusion(exprToFuse: Extension, node: StatsFetchNode) extends FusionPattern

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternRewrite.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternRewrite.scala
@@ -1,15 +1,7 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
+import org.eclipse.rdf4j.query.algebra.{BinaryTupleOperator, BindingSetAssignment, Filter, Group, Order, SingletonSet, Slice, TupleExpr, UnaryTupleOperator}
 import se.lu.nateko.cp.meta.services.sparql.index.DobjUri
-import org.eclipse.rdf4j.query.algebra.SingletonSet
-import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator
-import org.eclipse.rdf4j.query.algebra.TupleExpr
-import org.eclipse.rdf4j.query.algebra.Slice
-import org.eclipse.rdf4j.query.algebra.Order
-import org.eclipse.rdf4j.query.algebra.Group
-import org.eclipse.rdf4j.query.algebra.Filter
-import org.eclipse.rdf4j.query.algebra.UnaryTupleOperator
-import org.eclipse.rdf4j.query.algebra.BindingSetAssignment
 
 object DofPatternRewrite{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternRewrite.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternRewrite.scala
@@ -1,7 +1,6 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import org.eclipse.rdf4j.query.algebra.{BinaryTupleOperator, BindingSetAssignment, Filter, Group, Order, SingletonSet, Slice, TupleExpr, UnaryTupleOperator}
-import se.lu.nateko.cp.meta.services.sparql.index.DobjUri
+import org.eclipse.rdf4j.query.algebra.{BinaryTupleOperator, Filter, Group, Order, SingletonSet, Slice, TupleExpr, UnaryTupleOperator}
 
 object DofPatternRewrite{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternSearch.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternSearch.scala
@@ -1,13 +1,12 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import scala.jdk.CollectionConverters.IterableHasAsScala
-
-import org.eclipse.rdf4j.query.algebra.*
 import org.eclipse.rdf4j.model.IRI
+import org.eclipse.rdf4j.query.algebra.*
 import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.utils.asOptInstanceOf
+import se.lu.nateko.cp.meta.utils.rdf4j.*
 
+import scala.jdk.CollectionConverters.IterableHasAsScala
 
 import DofPatternSearch.*
 import StatsFetchPatternSearch.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/FilterPatternSearch.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/FilterPatternSearch.scala
@@ -1,21 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Value
 import org.eclipse.rdf4j.model.vocabulary.GEO
-import org.eclipse.rdf4j.query.algebra.And
-import org.eclipse.rdf4j.query.algebra.Compare
-import org.eclipse.rdf4j.query.algebra.Exists
-import org.eclipse.rdf4j.query.algebra.Filter
-import org.eclipse.rdf4j.query.algebra.Join
-import org.eclipse.rdf4j.query.algebra.Not
-import org.eclipse.rdf4j.query.algebra.Or
-import org.eclipse.rdf4j.query.algebra.StatementPattern
-import org.eclipse.rdf4j.query.algebra.ValueConstant
-import org.eclipse.rdf4j.query.algebra.ValueExpr
-import org.eclipse.rdf4j.query.algebra.Var
-import org.eclipse.rdf4j.query.algebra.{Regex => RdfRegex}
+import org.eclipse.rdf4j.model.{IRI, Literal, Value}
+import org.eclipse.rdf4j.query.algebra.{And, Compare, Exists, Not, Or, Regex as RdfRegex, StatementPattern, ValueConstant, ValueExpr, Var}
 import org.locationtech.jts.io.WKTReader
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap.*
 import se.lu.nateko.cp.meta.services.CpmetaVocab
@@ -24,7 +11,6 @@ import se.lu.nateko.cp.meta.services.sparql.index.*
 import se.lu.nateko.cp.meta.utils.asOptInstanceOf
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import java.time.Instant
 import scala.util.Try
 import scala.util.matching.Regex
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/StatsFetchNode.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/StatsFetchNode.scala
@@ -1,9 +1,10 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import scala.jdk.CollectionConverters.SeqHasAsJava
 import org.eclipse.rdf4j.query.algebra.*
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics
 import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchPatternSearch.GroupPattern
+
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 class StatsFetchNode(
 	val countVarName: String,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/StatsFetchPatternSearch.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/StatsFetchPatternSearch.scala
@@ -1,12 +1,9 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import scala.jdk.CollectionConverters.*
-import org.eclipse.rdf4j.query.algebra.Group
-import org.eclipse.rdf4j.query.algebra.Count
-import org.eclipse.rdf4j.query.algebra.Var
-import org.eclipse.rdf4j.query.algebra.Extension
-import org.eclipse.rdf4j.query.algebra.ValueExpr
+import org.eclipse.rdf4j.query.algebra.{Count, Extension, Group, ValueExpr, Var}
 import se.lu.nateko.cp.meta.services.sparql.index.Filter
+
+import scala.jdk.CollectionConverters.*
 
 
 object StatsFetchPatternSearch{

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/package.scala
@@ -1,7 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import scala.annotation.tailrec
 import org.eclipse.rdf4j.query.algebra.*
+
+import scala.annotation.tailrec
 
 def splitTriple(sp: StatementPattern) = (sp.getSubjectVar, sp.getPredicateVar, sp.getObjectVar)
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -3,10 +3,11 @@ package se.lu.nateko.cp.meta.services.sparql.magic.index
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value}
 import org.roaringbitmap.buffer.MutableRoaringBitmap
+import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.core.algo.DatetimeHierarchicalBitmap.DateTimeGeo
 import se.lu.nateko.cp.meta.core.algo.{DatetimeHierarchicalBitmap, HierarchicalBitmap}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.{TriplestoreConnection => TSC}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection as TSC
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
 import se.lu.nateko.cp.meta.services.sparql.index.StringHierarchicalBitmap.StringGeo
 import se.lu.nateko.cp.meta.services.sparql.index.{FileSizeHierarchicalBitmap, SamplingHeightHierarchicalBitmap, *}
@@ -17,7 +18,6 @@ import se.lu.nateko.cp.meta.utils.{asOptInstanceOf, parseCommaSepList, parseJson
 import java.time.Instant
 import scala.collection.IndexedSeq as IndSeq
 import scala.collection.mutable.{AnyRefMap, ArrayBuffer}
-import org.slf4j.LoggerFactory
 
 final class DataStartGeo(objs: IndSeq[ObjEntry]) extends DateTimeGeo(objs(_).dataStart)
 final class DataEndGeo(objs: IndSeq[ObjEntry]) extends DateTimeGeo(objs(_).dataEnd)

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -9,8 +9,8 @@ import se.lu.nateko.cp.meta.core.algo.{DatetimeHierarchicalBitmap, HierarchicalB
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection as TSC
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
+import se.lu.nateko.cp.meta.services.sparql.index.*
 import se.lu.nateko.cp.meta.services.sparql.index.StringHierarchicalBitmap.StringGeo
-import se.lu.nateko.cp.meta.services.sparql.index.{FileSizeHierarchicalBitmap, SamplingHeightHierarchicalBitmap, *}
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.{===, Rdf4jStatement, asString, toJava}
 import se.lu.nateko.cp.meta.utils.{asOptInstanceOf, parseCommaSepList, parseJsonStringArray}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/ObjEntry.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/ObjEntry.scala
@@ -3,6 +3,7 @@ package se.lu.nateko.cp.meta.services.sparql.magic.index
 import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.services.sparql.magic.ObjInfo
+
 import java.time.Instant
 import scala.compiletime.uninitialized
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/CollectionFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/CollectionFetcher.scala
@@ -2,19 +2,15 @@ package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
 import se.lu.nateko.cp.meta.api.RdfLens
-import se.lu.nateko.cp.meta.api.RdfLens.CollConn
-import se.lu.nateko.cp.meta.api.RdfLens.DocConn
+import se.lu.nateko.cp.meta.api.RdfLens.{CollConn, DocConn}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/CollectionFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/CollectionFetcher.scala
@@ -1,16 +1,13 @@
 package se.lu.nateko.cp.meta.services.upload
-
-import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import org.eclipse.rdf4j.model.vocabulary.RDFS
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.api.RdfLens.{CollConn, DocConn}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
-import se.lu.nateko.cp.meta.services.citation.CitationMaker
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/CpmetaFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/CpmetaFetcher.scala
@@ -1,19 +1,16 @@
 package se.lu.nateko.cp.meta.services.upload
 
+import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
-import org.eclipse.rdf4j.model.{IRI, ValueFactory}
-import se.lu.nateko.cp.meta.api.RdfLens.CollConn
-import se.lu.nateko.cp.meta.api.{RdfLens, UriId}
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.metaflow.TcMetaSource
-import se.lu.nateko.cp.meta.services.{CpmetaVocab, MetadataException}
+import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.utils.{Validated, containsEither, parseCommaSepList}
 
 import java.net.URI
-import scala.util.Try
 
 
 trait CpmetaReader:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/CpmetaFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/CpmetaFetcher.scala
@@ -1,25 +1,19 @@
 package se.lu.nateko.cp.meta.services.upload
 
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import se.lu.nateko.cp.meta.api.RdfLens
-import se.lu.nateko.cp.meta.api.UriId
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
+import se.lu.nateko.cp.meta.api.RdfLens.CollConn
+import se.lu.nateko.cp.meta.api.{RdfLens, UriId}
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.metaflow.TcMetaSource
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.containsEither
-import se.lu.nateko.cp.meta.utils.parseCommaSepList
+import se.lu.nateko.cp.meta.services.{CpmetaVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.utils.{Validated, containsEither, parseCommaSepList}
 
 import java.net.URI
 import scala.util.Try
-import se.lu.nateko.cp.meta.api.RdfLens.CollConn
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 
 
 trait CpmetaReader:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DataObjectInstanceServers.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DataObjectInstanceServers.scala
@@ -1,32 +1,20 @@
 package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import org.eclipse.rdf4j.repository.Repository
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.DocObjectDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.DataObjectSpec
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.core.data.Station
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, EnvriConfigs, Station}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.services.UploadUserErrorException
-import se.lu.nateko.cp.meta.services.citation.CitationMaker
-import se.lu.nateko.cp.meta.services.citation.CitationProvider
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, Rdf4jInstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.citation.{CitationMaker, CitationProvider}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.*
+import se.lu.nateko.cp.meta.{DataObjectDto, DocObjectDto, ObjectUploadDto}
 
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Success, Try}
 
 
 class DataObjectInstanceServers(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DataObjectInstanceServers.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DataObjectInstanceServers.scala
@@ -1,20 +1,14 @@
 package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.model.{IRI, ValueFactory}
-import org.eclipse.rdf4j.repository.Repository
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, EnvriConfigs, Station}
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, Rdf4jInstanceServer, TriplestoreConnection}
-import se.lu.nateko.cp.meta.services.citation.{CitationMaker, CitationProvider}
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException, UploadUserErrorException}
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.instanceserver.InstanceServer
+import se.lu.nateko.cp.meta.services.citation.CitationProvider
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.*
-import se.lu.nateko.cp.meta.{DataObjectDto, DocObjectDto, ObjectUploadDto}
-
-import scala.util.{Success, Try}
 
 
 class DataObjectInstanceServers(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
@@ -4,8 +4,8 @@ import org.eclipse.rdf4j.model.IRI
 import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.services.CpVocab
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.utils.{Validated, parseCommaSepList, parseJsonStringArray}
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
@@ -1,25 +1,16 @@
 package se.lu.nateko.cp.meta.services.upload
 
-import java.time.LocalDate
-import java.time.ZoneId
-
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.RDF
-
-import scala.util.Try
-
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.utils.parseCommaSepList
-import se.lu.nateko.cp.meta.utils.parseJsonStringArray
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.utils.Validated
+import se.lu.nateko.cp.meta.utils.{Validated, parseCommaSepList, parseJsonStringArray}
+
+import java.time.{LocalDate, ZoneId}
+import scala.util.Try
 
 
 trait DobjMetaReader(val vocab: CpVocab) extends CpmetaReader:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiClientFactory.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiClientFactory.scala
@@ -2,7 +2,7 @@ package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.doi.core.{DoiClient, DoiClientConfig, DoiReadonlyClient, PlainJavaDoiHttp}
-import se.lu.nateko.cp.meta.{CpmetaConfig, DoiConfig}
+import se.lu.nateko.cp.meta.DoiConfig
 
 import scala.concurrent.ExecutionContext
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiClientFactory.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiClientFactory.scala
@@ -1,14 +1,10 @@
 package se.lu.nateko.cp.meta.services.upload
 
-import se.lu.nateko.cp.doi.core.DoiClient
-import se.lu.nateko.cp.doi.core.DoiClientConfig
-import se.lu.nateko.cp.doi.core.DoiReadonlyClient
-import se.lu.nateko.cp.doi.core.PlainJavaDoiHttp
-import se.lu.nateko.cp.meta.CpmetaConfig
-import se.lu.nateko.cp.meta.DoiConfig
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.doi.core.{DoiClient, DoiClientConfig, DoiReadonlyClient, PlainJavaDoiHttp}
+import se.lu.nateko.cp.meta.{CpmetaConfig, DoiConfig}
 
 import scala.concurrent.ExecutionContext
-import eu.icoscp.envri.Envri
 
 class DoiClientFactory(conf: DoiConfig)(using ExecutionContext):
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiService.scala
@@ -3,36 +3,21 @@ package se.lu.nateko.cp.meta.services.upload
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.MediaTypes
-import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.{HttpRequest, MediaTypes, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import se.lu.nateko.cp.doi.CoolDoi
-import se.lu.nateko.cp.doi.Doi
-import se.lu.nateko.cp.doi.DoiMeta
-import se.lu.nateko.cp.doi.core.DoiClient
-import se.lu.nateko.cp.doi.core.DoiClientConfig
-import se.lu.nateko.cp.doi.core.PlainJavaDoiHttp
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.doi.core.{DoiClient, DoiClientConfig, PlainJavaDoiHttp}
+import se.lu.nateko.cp.doi.{CoolDoi, Doi, DoiMeta}
 import se.lu.nateko.cp.meta.DoiConfig
-import se.lu.nateko.cp.meta.core.data.DataObject
-import se.lu.nateko.cp.meta.core.data.DataProduction
-import se.lu.nateko.cp.meta.core.data.DocObject
-import se.lu.nateko.cp.meta.core.data.FeatureCollection
-import se.lu.nateko.cp.meta.core.data.PlainStaticObject
-import se.lu.nateko.cp.meta.core.data.StaticCollection
-import se.lu.nateko.cp.meta.core.data.StaticObject
+import se.lu.nateko.cp.meta.core.data.{DataObject, DataProduction, DocObject, FeatureCollection, PlainStaticCollection, PlainStaticObject, StaticCollection, StaticObject}
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
+import se.lu.nateko.cp.meta.services.metaexport.DataCite
+import se.lu.nateko.cp.meta.utils.Validated
 
 import java.net.URI
-import java.time.Year
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import java.time.Instant
-import se.lu.nateko.cp.meta.services.metaexport.DataCite
-import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.core.data.PlainStaticCollection
+import java.time.{Instant, Year}
+import scala.concurrent.{ExecutionContext, Future}
 
 class DoiService(doiConf: DoiConfig, fetcher: UriSerializer)(using ExecutionContext) {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DoiService.scala
@@ -1,22 +1,14 @@
 package se.lu.nateko.cp.meta.services.upload
-
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
-import akka.http.scaladsl.model.headers.Accept
-import akka.http.scaladsl.model.{HttpRequest, MediaTypes, Uri}
-import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.http.scaladsl.model.Uri
 import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.doi.core.{DoiClient, DoiClientConfig, PlainJavaDoiHttp}
-import se.lu.nateko.cp.doi.{CoolDoi, Doi, DoiMeta}
+import se.lu.nateko.cp.doi.{Doi, DoiMeta}
 import se.lu.nateko.cp.meta.DoiConfig
-import se.lu.nateko.cp.meta.core.data.{DataObject, DataProduction, DocObject, FeatureCollection, PlainStaticCollection, PlainStaticObject, StaticCollection, StaticObject}
+import se.lu.nateko.cp.meta.core.data.{DataObject, DocObject, PlainStaticCollection, PlainStaticObject, StaticCollection, StaticObject}
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer
 import se.lu.nateko.cp.meta.services.metaexport.DataCite
 import se.lu.nateko.cp.meta.utils.Validated
 
 import java.net.URI
-import java.time.{Instant, Year}
 import scala.concurrent.{ExecutionContext, Future}
 
 class DoiService(doiConf: DoiConfig, fetcher: UriSerializer)(using ExecutionContext) {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/MetadataUpdater.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/MetadataUpdater.scala
@@ -3,17 +3,13 @@ package se.lu.nateko.cp.meta.services.upload
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.model.{IRI, Resource, Statement, ValueFactory}
-import se.lu.nateko.cp.meta.api.RdfLens.{CollConn, GlobConn}
+import se.lu.nateko.cp.meta.api.RdfLens.CollConn
 import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{getOptionalUri, getStatements, getUriValues, hasStatement}
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{getStatements, getUriValues}
+import se.lu.nateko.cp.meta.instanceserver.{RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.Using
 
 abstract class MetadataUpdater(vocab: CpVocab):
 	import MetadataUpdater.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/MetadataUpdater.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/MetadataUpdater.scala
@@ -1,31 +1,18 @@
 package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Resource
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.RDF
-import se.lu.nateko.cp.meta.api.RdfLens.CollConn
-import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
+import org.eclipse.rdf4j.model.{IRI, Resource, Statement, ValueFactory}
+import se.lu.nateko.cp.meta.api.RdfLens.{CollConn, GlobConn}
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.getOptionalUri
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.getStatements
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.getUriValues
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.hasStatement
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.{getOptionalUri, getStatements, getUriValues, hasStatement}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
 import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Using
 
 abstract class MetadataUpdater(vocab: CpVocab):

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
@@ -15,6 +15,7 @@ import se.lu.nateko.cp.meta.utils.{Validated, getStackTrace}
 import se.lu.nateko.cp.meta.views.LandingPageExtras
 import spray.json.*
 import views.html.{CollectionLandingPage, LandingPage, MessagePage}
+
 import java.util.concurrent.ExecutionException
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/StatementsProducer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/StatementsProducer.scala
@@ -6,7 +6,7 @@ import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
 import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.{GeoFeature, GeoJson, LatLonBox, Position, flattenToSeq}
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.*

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/StatementsProducer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/StatementsProducer.scala
@@ -1,42 +1,21 @@
 package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import org.eclipse.rdf4j.model.vocabulary.XSD
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.DataProductionDto
-import se.lu.nateko.cp.meta.DocObjectDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.SpatioTemporalDto
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.StationTimeSeriesDto
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS, XSD}
+import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
 import se.lu.nateko.cp.meta.api.UriId
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import se.lu.nateko.cp.meta.core.data.GeoJson
-import se.lu.nateko.cp.meta.core.data.LatLonBox
-import se.lu.nateko.cp.meta.core.data.Position
-import se.lu.nateko.cp.meta.core.data.flattenToSeq
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.UploadUserErrorException
+import se.lu.nateko.cp.meta.core.data.{GeoFeature, GeoJson, LatLonBox, Position, flattenToSeq}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.{DataObjectDto, DataProductionDto, DocObjectDto, GeoCoverage, GeoJsonString, ObjectUploadDto, SpatioTemporalDto, StaticCollectionDto, StationTimeSeriesDto}
 
 import java.net.URI
 import java.time.Instant
 import scala.collection.mutable.Buffer
-import se.lu.nateko.cp.meta.GeoJsonString
-import se.lu.nateko.cp.meta.GeoCoverage
 
 class StatementsProducer(vocab: CpVocab, metaVocab: CpmetaVocab) {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/StaticObjectFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/StaticObjectFetcher.scala
@@ -2,21 +2,15 @@ package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.RDFS
-import se.lu.nateko.cp.meta.api.HandleNetClient
-import se.lu.nateko.cp.meta.api.RdfLens
-import se.lu.nateko.cp.meta.api.RdfLenses
+import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens, RdfLenses}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
-import se.lu.nateko.cp.meta.utils.Validated
-import se.lu.nateko.cp.meta.utils.parseCommaSepList
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.utils.{Validated, parseCommaSepList}
 
 import java.net.URI
 import java.time.Instant

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/StaticObjectFetcher.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/StaticObjectFetcher.scala
@@ -2,15 +2,15 @@ package se.lu.nateko.cp.meta.services.upload
 
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.vocabulary.{RDF, RDFS}
+import org.eclipse.rdf4j.model.vocabulary.RDFS
 import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens, RdfLenses}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import se.lu.nateko.cp.meta.utils.{Validated, parseCommaSepList}
 
 import java.net.URI
 import java.time.Instant

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadLock.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadLock.scala
@@ -5,11 +5,8 @@ import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.services.MetadataException
 
 import scala.collection.mutable.Set
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 private[upload] class UploadLock {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadService.scala
@@ -32,7 +32,7 @@ class UploadService(
 	conf: UploadServiceConfig
 )(using system: ActorSystem, mat: Materializer):
 
-	import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection.*
+	
 	import RdfLens.GlobConn
 	import servers.{ metaVocab, vocab, metaReader }
 	import system.{ dispatcher, log }

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadService.scala
@@ -1,38 +1,28 @@
 package se.lu.nateko.cp.meta.services.upload
 
-import java.net.URI
-
-import scala.concurrent.Future
-import scala.util.Try
-
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
+import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.ValueFactory
 import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.meta.{ ObjectUploadDto, StaticCollectionDto, SubmitterProfile, UploadServiceConfig }
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.DocObjectDto
-import se.lu.nateko.cp.meta.api.HandleNetClient
-import se.lu.nateko.cp.meta.api.SparqlRunner
+import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens, SparqlRunner}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.core.data.UploadCompletionInfo
+import se.lu.nateko.cp.meta.core.data.{UploadCompletionInfo, *}
 import se.lu.nateko.cp.meta.core.etcupload.EtcUploadMetadata
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
-import se.lu.nateko.cp.meta.services.UploadUserErrorException
-import se.lu.nateko.cp.meta.services.upload.completion.UploadCompleter
+import se.lu.nateko.cp.meta.services.upload.completion.{Report, UploadCompleter}
 import se.lu.nateko.cp.meta.services.upload.etc.EtcUploadTransformer
 import se.lu.nateko.cp.meta.services.upload.validation.UploadValidator
-import se.lu.nateko.cp.meta.utils.rdf4j.*
-import se.lu.nateko.cp.meta.services.upload.completion.Report
-import se.lu.nateko.cp.meta.ConfigLoader
-import org.eclipse.rdf4j.model.ValueFactory
-import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.api.RdfLens
-import akka.http.scaladsl.model.Uri
+import se.lu.nateko.cp.meta.services.{MetadataException, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.Validated
-import scala.util.Success
+import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.{ConfigLoader, DataObjectDto, DocObjectDto, ObjectUploadDto, StaticCollectionDto, SubmitterProfile, UploadServiceConfig}
+
+import java.net.URI
+import scala.concurrent.Future
+import scala.util.{Success, Try}
 
 class AccessUri(val uri: URI)
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadService.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/UploadService.scala
@@ -8,7 +8,7 @@ import org.eclipse.rdf4j.model.ValueFactory
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens, SparqlRunner}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.{UploadCompletionInfo, *}
+import se.lu.nateko.cp.meta.core.data.{UploadCompletionInfo, FeatureCollection, GeoFeature, DataObject, DocObject}
 import se.lu.nateko.cp.meta.core.etcupload.EtcUploadMetadata
 import se.lu.nateko.cp.meta.instanceserver.InstanceServer
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/VarMetaLookup.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/VarMetaLookup.scala
@@ -1,11 +1,9 @@
 package se.lu.nateko.cp.meta.services.upload
 
-import scala.util.matching.Regex
+import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment, UriResource, ValueType, VarMeta}
+
 import java.net.URI
-import se.lu.nateko.cp.meta.core.data.ValueType
-import se.lu.nateko.cp.meta.core.data.VarMeta
-import se.lu.nateko.cp.meta.core.data.UriResource
-import se.lu.nateko.cp.meta.core.data.InstrumentDeployment
+import scala.util.matching.Regex
 
 class DatasetVariable(
 	val self: UriResource,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/VarMetaLookup.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/VarMetaLookup.scala
@@ -1,6 +1,6 @@
 package se.lu.nateko.cp.meta.services.upload
 
-import se.lu.nateko.cp.meta.core.data.{InstrumentDeployment, UriResource, ValueType, VarMeta}
+import se.lu.nateko.cp.meta.core.data.{UriResource, ValueType, VarMeta}
 
 import java.net.URI
 import scala.util.matching.Regex

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/FormatSpecificCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/FormatSpecificCompleter.scala
@@ -1,8 +1,7 @@
 package se.lu.nateko.cp.meta.services.upload.completion
 
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.instanceserver.{RdfUpdate, TriplestoreConnection}
 
 import scala.concurrent.Future
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/NetCdfUploadCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/NetCdfUploadCompleter.scala
@@ -1,15 +1,13 @@
 package se.lu.nateko.cp.meta.services.upload.completion
 
 import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.api.HandleNetClient
 import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
-import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.NetCdfExtract
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
+import se.lu.nateko.cp.meta.instanceserver.{RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.upload.MetadataUpdater
 import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
-
-import scala.concurrent.{ExecutionContext, Future}
 
 
 private class NetCdfUploadCompleter(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/NetCdfUploadCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/NetCdfUploadCompleter.scala
@@ -1,20 +1,15 @@
 package se.lu.nateko.cp.meta.services.upload.completion
 
 import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.api.HandleNetClient
-import se.lu.nateko.cp.meta.api.RdfLens
+import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
+import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.NetCdfExtract
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.upload.MetadataUpdater
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
+import scala.concurrent.{ExecutionContext, Future}
 
 
 private class NetCdfUploadCompleter(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/PidMinter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/PidMinter.scala
@@ -3,12 +3,10 @@ package se.lu.nateko.cp.meta.services.upload.completion
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.api.HandleNetClient
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.instanceserver.{RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.CpVocab
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class PidMinter(handles: HandleNetClient, vocab: CpVocab)(using Envri) extends FormatSpecificCompleter:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/TimeSeriesUploadCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/TimeSeriesUploadCompleter.scala
@@ -6,9 +6,9 @@ import se.lu.nateko.cp.meta.api.HandleNetClient
 import se.lu.nateko.cp.meta.api.RdfLens.{DobjConn, DobjLens}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
+import se.lu.nateko.cp.meta.instanceserver.{RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.upload.{MetadataUpdater, StatementsProducer}
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, UploadCompletionException}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.printAsJsonArray
 import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/TimeSeriesUploadCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/TimeSeriesUploadCompleter.scala
@@ -3,18 +3,12 @@ package se.lu.nateko.cp.meta.services.upload.completion
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.IRI
 import se.lu.nateko.cp.meta.api.HandleNetClient
-import se.lu.nateko.cp.meta.api.RdfLens.DobjConn
-import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
+import se.lu.nateko.cp.meta.api.RdfLens.{DobjConn, DobjLens}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.UploadCompletionException
-import se.lu.nateko.cp.meta.services.upload.MetadataUpdater
-import se.lu.nateko.cp.meta.services.upload.StatementsProducer
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.upload.{MetadataUpdater, StatementsProducer}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, UploadCompletionException}
 import se.lu.nateko.cp.meta.utils.printAsJsonArray
 import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/UploadCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/UploadCompleter.scala
@@ -1,27 +1,18 @@
 package se.lu.nateko.cp.meta.services.upload.completion
 
 import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.api.HandleNetClient
+import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
+import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.IngestionMetadataExtract
-import se.lu.nateko.cp.meta.core.data.NetCdfExtract
-import se.lu.nateko.cp.meta.core.data.SpatialTimeSeriesExtract
-import se.lu.nateko.cp.meta.core.data.TimeSeriesExtract
-import se.lu.nateko.cp.meta.core.data.UploadCompletionInfo
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
+import se.lu.nateko.cp.meta.core.data.{IngestionMetadataExtract, NetCdfExtract, SpatialTimeSeriesExtract, TimeSeriesExtract, UploadCompletionInfo}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
+import se.lu.nateko.cp.meta.services.MetadataException
 import se.lu.nateko.cp.meta.services.upload.DataObjectInstanceServers
-
 import se.lu.nateko.cp.meta.utils.rdf4j.toJava
 
 import java.time.Instant
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.api.RdfLens
-import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
 
 
 class UploadCompleter(servers: DataObjectInstanceServers, handles: HandleNetClient)(using ExecutionContext):

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/UploadCompleter.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/completion/UploadCompleter.scala
@@ -4,7 +4,7 @@ import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.api.RdfLens.DobjLens
 import se.lu.nateko.cp.meta.api.{HandleNetClient, RdfLens}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.{IngestionMetadataExtract, NetCdfExtract, SpatialTimeSeriesExtract, TimeSeriesExtract, UploadCompletionInfo}
+import se.lu.nateko.cp.meta.core.data.{NetCdfExtract, SpatialTimeSeriesExtract, TimeSeriesExtract, UploadCompletionInfo}
 import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.MetadataException
 import se.lu.nateko.cp.meta.services.upload.DataObjectInstanceServers
@@ -12,7 +12,6 @@ import se.lu.nateko.cp.meta.utils.rdf4j.toJava
 
 import java.time.Instant
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 
 class UploadCompleter(servers: DataObjectInstanceServers, handles: HandleNetClient)(using ExecutionContext):

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcFileMetadata.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcFileMetadata.scala
@@ -1,7 +1,6 @@
 package se.lu.nateko.cp.meta.services.upload.etc
 
 import se.lu.nateko.cp.meta.core.etcupload.{DataType, StationId}
-import se.lu.nateko.cp.meta.ingestion.badm.{Badm, BadmEntry, BadmValue}
 
 case class EtcFileMeta(dtype: DataType, isBinary: Boolean)
 case class EtcFileMetaKey(station: StationId, loggerId: Int, fileId: Int, dataType: DataType)

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcFileMetadata.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcFileMetadata.scala
@@ -1,7 +1,6 @@
 package se.lu.nateko.cp.meta.services.upload.etc
 
-import se.lu.nateko.cp.meta.core.etcupload.DataType
-import se.lu.nateko.cp.meta.core.etcupload.StationId
+import se.lu.nateko.cp.meta.core.etcupload.{DataType, StationId}
 import se.lu.nateko.cp.meta.ingestion.badm.{Badm, BadmEntry, BadmValue}
 
 case class EtcFileMeta(dtype: DataType, isBinary: Boolean)

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcFileMetadataProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcFileMetadataProvider.scala
@@ -1,16 +1,15 @@
 package se.lu.nateko.cp.meta.services.upload.etc
 
-import scala.concurrent.duration.*
-import scala.util.Failure
-import scala.util.Success
-
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.stream.Materializer
-import se.lu.nateko.cp.meta.core.etcupload.StationId
 import se.lu.nateko.cp.meta.EtcConfig
+import se.lu.nateko.cp.meta.core.etcupload.StationId
 import se.lu.nateko.cp.meta.metaflow.icos.EtcMetaSource
 import se.lu.nateko.cp.meta.services.CpVocab
-import akka.event.Logging
+
+import scala.concurrent.duration.*
+import scala.util.{Failure, Success}
 
 class EtcFileMetadataProvider(conf: EtcConfig, vocab: CpVocab)(using system: ActorSystem) extends EtcFileMetadataStore{
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcUploadTransformer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcUploadTransformer.scala
@@ -1,7 +1,6 @@
 package se.lu.nateko.cp.meta.services.upload.etc
 
 import akka.actor.ActorSystem
-import akka.stream.Materializer
 import eu.icoscp.envri.Envri
 import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner, UriId}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcUploadTransformer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/etc/EtcUploadTransformer.scala
@@ -1,29 +1,19 @@
 package se.lu.nateko.cp.meta.services.upload.etc
 
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-
-import scala.util.Try
-
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import se.lu.nateko.cp.meta.EtcConfig
-import se.lu.nateko.cp.meta.StationTimeSeriesDto
-import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.api.SparqlRunner
-import se.lu.nateko.cp.meta.api.UriId
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlRunner, UriId}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.TimeInterval
-import se.lu.nateko.cp.meta.core.etcupload.DataType
-import se.lu.nateko.cp.meta.core.etcupload.EtcUploadMetadata
-import se.lu.nateko.cp.meta.core.etcupload.StationId
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.MetadataException
+import se.lu.nateko.cp.meta.core.etcupload.{DataType, EtcUploadMetadata, StationId}
+import se.lu.nateko.cp.meta.services.{CpVocab, MetadataException}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import scala.util.Success
-import se.lu.nateko.cp.meta.DataObjectDto
-import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.{DataObjectDto, EtcConfig, StationTimeSeriesDto}
+
+import java.time.{LocalDateTime, ZoneOffset}
+import scala.util.{Success, Try}
 
 class EtcUploadTransformer(sparqler: SparqlRunner, config: EtcConfig, vocab: CpVocab)(using ActorSystem) {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/geocov/GeoCluster.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/geocov/GeoCluster.scala
@@ -1,11 +1,12 @@
 package se.lu.nateko.cp.meta.services.upload.geocov
 
-import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.algorithm.ConvexHull
-import se.lu.nateko.cp.meta.services.sparql.magic.JtsGeoFactory
-import org.locationtech.jts.simplify.DouglasPeuckerSimplifier
-import scala.collection.mutable
+import org.locationtech.jts.geom.Geometry
 import org.locationtech.jts.operation.union.UnaryUnionOp
+import org.locationtech.jts.simplify.DouglasPeuckerSimplifier
+import se.lu.nateko.cp.meta.services.sparql.magic.JtsGeoFactory
+
+import scala.collection.mutable
 
 object GeoCluster:
 	val MaxGeoDigestSize = 15

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/geocov/GeoCovMerger.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/geocov/GeoCovMerger.scala
@@ -2,30 +2,15 @@ package se.lu.nateko.cp.meta.services.upload.geocov
 
 import org.locationtech.jts.algorithm.ConvexHull
 import org.locationtech.jts.algorithm.hull.ConcaveHull
-import org.locationtech.jts.geom.Coordinate
-import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryCollection
-import org.locationtech.jts.geom.LineString
-import org.locationtech.jts.geom.Point as JtsPoint
-import org.locationtech.jts.geom.Polygon as JtsPolygon
+import org.locationtech.jts.geom.{Coordinate, Envelope, Geometry, GeometryCollection, LineString, Point as JtsPoint, Polygon as JtsPolygon}
+import org.locationtech.jts.index.strtree.STRtree
 import org.locationtech.jts.io.geojson.GeoJsonReader
 import se.lu.nateko.cp.doi.meta.GeoLocation
-import se.lu.nateko.cp.meta.core.data.Circle
-import se.lu.nateko.cp.meta.core.data.FeatureCollection
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import se.lu.nateko.cp.meta.core.data.GeoTrack
-import se.lu.nateko.cp.meta.core.data.LatLonBox
-import se.lu.nateko.cp.meta.core.data.Pin
-import se.lu.nateko.cp.meta.core.data.Polygon
-import se.lu.nateko.cp.meta.core.data.Position
+import se.lu.nateko.cp.meta.core.data.{Circle, FeatureCollection, FeatureWithGeoJson, GeoFeature, GeoTrack, LatLonBox, Pin, Polygon, Position, PositionUtil}
 import se.lu.nateko.cp.meta.core.etcupload.StationId
-import se.lu.nateko.cp.meta.services.sparql.magic.ConcaveHullLengthRatio
-import se.lu.nateko.cp.meta.services.sparql.magic.JtsGeoFactory
-import se.lu.nateko.cp.meta.core.data.PositionUtil
+import se.lu.nateko.cp.meta.services.sparql.magic.{ConcaveHullLengthRatio, JtsGeoFactory}
+
 import scala.collection.mutable.ArrayBuffer
-import org.locationtech.jts.index.strtree.STRtree
-import org.locationtech.jts.geom.Envelope
-import se.lu.nateko.cp.meta.core.data.FeatureWithGeoJson
 
 
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/geocov/GeoCovMerger.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/geocov/GeoCovMerger.scala
@@ -1,16 +1,10 @@
 package se.lu.nateko.cp.meta.services.upload.geocov
-
-import org.locationtech.jts.algorithm.ConvexHull
 import org.locationtech.jts.algorithm.hull.ConcaveHull
 import org.locationtech.jts.geom.{Coordinate, Envelope, Geometry, GeometryCollection, LineString, Point as JtsPoint, Polygon as JtsPolygon}
 import org.locationtech.jts.index.strtree.STRtree
-import org.locationtech.jts.io.geojson.GeoJsonReader
-import se.lu.nateko.cp.doi.meta.GeoLocation
-import se.lu.nateko.cp.meta.core.data.{Circle, FeatureCollection, FeatureWithGeoJson, GeoFeature, GeoTrack, LatLonBox, Pin, Polygon, Position, PositionUtil}
+import se.lu.nateko.cp.meta.core.data.{Circle, FeatureCollection, FeatureWithGeoJson, GeoFeature, GeoTrack, LatLonBox, Pin, Polygon, Position}
 import se.lu.nateko.cp.meta.core.etcupload.StationId
 import se.lu.nateko.cp.meta.services.sparql.magic.{ConcaveHullLengthRatio, JtsGeoFactory}
-
-import scala.collection.mutable.ArrayBuffer
 
 
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/ScopedValidator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/ScopedValidator.scala
@@ -2,26 +2,22 @@ package se.lu.nateko.cp.meta.services.upload.validation
 
 import akka.NotUsed
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.model.{IRI, ValueFactory}
-import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, DatasetType, OptionalOneOrSeq, TimeInterval, flattenToSeq}
-import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
+import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, OptionalOneOrSeq, TimeInterval, flattenToSeq}
+import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
 import se.lu.nateko.cp.meta.services.upload.CpmetaReader
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, UnauthorizedUploadException, UploadUserErrorException}
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import se.lu.nateko.cp.meta.{ConfigLoader, DataObjectDto, DataProductionDto, DataSubmitterConfig, DocObjectDto, ObjectUploadDto, StaticCollectionDto, StationTimeSeriesDto, UploadDto, UploadServiceConfig}
+import se.lu.nateko.cp.meta.{DataObjectDto, DataSubmitterConfig, DocObjectDto, ObjectUploadDto, StationTimeSeriesDto}
 
 import java.net.URI
 import java.time.Instant
-import java.util.Date
-import scala.collection.mutable.Buffer
 import scala.language.strictEquality
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 private class ScopedValidator(vocab: CpVocab, val metaVocab: CpmetaVocab) extends CpmetaReader:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/ScopedValidator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/ScopedValidator.scala
@@ -1,48 +1,27 @@
 package se.lu.nateko.cp.meta.services.upload.validation
 
 import akka.NotUsed
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
+import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.meta.ConfigLoader
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.DataProductionDto
-import se.lu.nateko.cp.meta.DataSubmitterConfig
-import se.lu.nateko.cp.meta.DocObjectDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.StationTimeSeriesDto
-import se.lu.nateko.cp.meta.UploadDto
-import se.lu.nateko.cp.meta.UploadServiceConfig
 import se.lu.nateko.cp.meta.api.RdfLens
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.DataObjectSpec
-import se.lu.nateko.cp.meta.core.data.DatasetType
-import se.lu.nateko.cp.meta.core.data.OptionalOneOrSeq
-import se.lu.nateko.cp.meta.core.data.flattenToSeq
-import se.lu.nateko.cp.meta.core.data.TimeInterval
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.UnauthorizedUploadException
-import se.lu.nateko.cp.meta.services.UploadUserErrorException
+import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, DatasetType, OptionalOneOrSeq, TimeInterval, flattenToSeq}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, TriplestoreConnection}
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
 import se.lu.nateko.cp.meta.services.upload.CpmetaReader
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, UnauthorizedUploadException, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-
+import se.lu.nateko.cp.meta.{ConfigLoader, DataObjectDto, DataProductionDto, DataSubmitterConfig, DocObjectDto, ObjectUploadDto, StaticCollectionDto, StationTimeSeriesDto, UploadDto, UploadServiceConfig}
 
 import java.net.URI
 import java.time.Instant
 import java.util.Date
 import scala.collection.mutable.Buffer
 import scala.language.strictEquality
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import eu.icoscp.envri.Envri
+import scala.util.{Failure, Success, Try}
 
 private class ScopedValidator(vocab: CpVocab, val metaVocab: CpmetaVocab) extends CpmetaReader:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/UploadValidator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/UploadValidator.scala
@@ -2,24 +2,20 @@ package se.lu.nateko.cp.meta.services.upload.validation
 
 import akka.NotUsed
 import eu.icoscp.envri.Envri
-import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.cpauth.core.UserId
 import se.lu.nateko.cp.meta.api.{RdfLens, UriId}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, DatasetType, GeoFeature, GeoJson, OptionalOneOrSeq, TimeInterval, flattenToSeq}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
 import se.lu.nateko.cp.meta.services.upload.DataObjectInstanceServers
-import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException, UnauthorizedUploadException, UploadUserErrorException}
+import se.lu.nateko.cp.meta.services.{MetadataException, UnauthorizedUploadException, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import se.lu.nateko.cp.meta.{ConfigLoader, DataObjectDto, DataProductionDto, DataSubmitterConfig, DocObjectDto, GeoCoverage, GeoJsonString, ObjectUploadDto, StaticCollectionDto, UploadDto, UploadServiceConfig}
-import spray.json.JsonParser
+import se.lu.nateko.cp.meta.{ConfigLoader, DataObjectDto, DataProductionDto, DataSubmitterConfig, DocObjectDto, GeoCoverage, GeoJsonString, ObjectUploadDto, StaticCollectionDto, UploadDto}
 
 import java.net.URI
 import java.time.Instant
-import java.util.Date
 import scala.collection.mutable.Buffer
 import scala.language.strictEquality
 import scala.util.{Failure, Success, Try}
@@ -36,7 +32,7 @@ def authFail(msg: String) = Failure(new UnauthorizedUploadException(msg))
 class UploadValidator(servers: DataObjectInstanceServers):
 	import servers.{ metaVocab, vocab, metaReader, lenses }
 	import TriplestoreConnection.*
-	import RdfLens.{MetaConn, DobjConn, DocConn, CollConn, ItemConn, GlobConn}
+	import RdfLens.{MetaConn, DobjConn, DocConn, CollConn, GlobConn}
 	given vf: ValueFactory = metaVocab.factory
 	private val scoped = ScopedValidator(vocab, metaVocab)
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/UploadValidator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/UploadValidator.scala
@@ -1,52 +1,28 @@
 package se.lu.nateko.cp.meta.services.upload.validation
 
 import akka.NotUsed
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.ValueFactory
+import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, ValueFactory}
 import se.lu.nateko.cp.cpauth.core.UserId
-import se.lu.nateko.cp.meta.ConfigLoader
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.DataProductionDto
-import se.lu.nateko.cp.meta.DataSubmitterConfig
-import se.lu.nateko.cp.meta.DocObjectDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.UploadDto
-import se.lu.nateko.cp.meta.UploadServiceConfig
-import se.lu.nateko.cp.meta.api.RdfLens
+import se.lu.nateko.cp.meta.api.{RdfLens, UriId}
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.core.data.DataObjectSpec
-import se.lu.nateko.cp.meta.core.data.DatasetType
-import se.lu.nateko.cp.meta.core.data.OptionalOneOrSeq
-import se.lu.nateko.cp.meta.core.data.flattenToSeq
-import se.lu.nateko.cp.meta.core.data.TimeInterval
+import se.lu.nateko.cp.meta.core.data.{DataObjectSpec, DatasetType, GeoFeature, GeoJson, OptionalOneOrSeq, TimeInterval, flattenToSeq}
 import se.lu.nateko.cp.meta.instanceserver.TriplestoreConnection
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.UnauthorizedUploadException
-import se.lu.nateko.cp.meta.services.UploadUserErrorException
 import se.lu.nateko.cp.meta.services.linkeddata.UriSerializer.Hash
+import se.lu.nateko.cp.meta.services.upload.DataObjectInstanceServers
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, MetadataException, UnauthorizedUploadException, UploadUserErrorException}
 import se.lu.nateko.cp.meta.utils.*
 import se.lu.nateko.cp.meta.utils.rdf4j.*
+import se.lu.nateko.cp.meta.{ConfigLoader, DataObjectDto, DataProductionDto, DataSubmitterConfig, DocObjectDto, GeoCoverage, GeoJsonString, ObjectUploadDto, StaticCollectionDto, UploadDto, UploadServiceConfig}
+import spray.json.JsonParser
 
 import java.net.URI
 import java.time.Instant
 import java.util.Date
 import scala.collection.mutable.Buffer
 import scala.language.strictEquality
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.upload.DataObjectInstanceServers
-import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.services.MetadataException
-import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import spray.json.JsonParser
-import se.lu.nateko.cp.meta.core.data.GeoJson
-import se.lu.nateko.cp.meta.GeoCoverage
-import se.lu.nateko.cp.meta.GeoJsonString
+import scala.util.{Failure, Success, Try}
 
 given CanEqual[URI, URI] = CanEqual.derived
 given CanEqual[IRI, IRI] = CanEqual.derived

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/Validated.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/Validated.scala
@@ -1,11 +1,8 @@
 package se.lu.nateko.cp.meta.utils
 
 import scala.collection.mutable.Buffer
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext
-import scala.util.Try
-import scala.util.Success
-import scala.util.Failure
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 class Validated[+T](val result: Option[T], val errors: Seq[String] = Nil):
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/akkahttp/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/akkahttp/package.scala
@@ -1,15 +1,13 @@
 package se.lu.nateko.cp.meta.utils.akkahttp
 
-import akka.stream.Materializer
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.ResponseEntity
-import akka.http.scaladsl.model.StatusCodes
 import akka.Done
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import akka.http.scaladsl.model.{HttpResponse, ResponseEntity, StatusCodes}
+import akka.stream.Materializer
+import se.lu.nateko.cp.meta.utils.async.{error, ok}
+
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
-import se.lu.nateko.cp.meta.utils.async.{ok, error}
 
 def responseToDone(errCtxt: String)(resp: HttpResponse)(implicit ctxt: ExecutionContext, mat: Materializer): Future[Done] =
 	if(resp.status.isSuccess) {

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/async/CancellableAction.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/async/CancellableAction.scala
@@ -1,8 +1,9 @@
 package se.lu.nateko.cp.meta.utils.async
 
-import scala.concurrent.duration.*
 import akka.actor.Scheduler
+
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.*
 
 class CancellableAction(delay: FiniteDuration, scheduler: Scheduler)(action: => Unit)(implicit exe: ExecutionContext){
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/async/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/async/package.scala
@@ -1,16 +1,13 @@
 package se.lu.nateko.cp.meta.utils.async
 
+import akka.Done
+import akka.actor.Scheduler
+
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.control.NoStackTrace
-
-import akka.actor.Scheduler
-import akka.Done
 
 def ok: Future[Done] = Future.successful(Done)
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/json.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/json.scala
@@ -1,7 +1,6 @@
 package se.lu.nateko.cp.meta.utils.json
 
-import spray.json.JsObject
-import spray.json.JsValue
+import spray.json.{JsObject, JsValue}
 
 def merge(objs: JsObject*): JsObject = JsObject(objs.flatMap(_.fields)*)
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/owlapi/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/owlapi/package.scala
@@ -1,12 +1,13 @@
 package se.lu.nateko.cp.meta.utils.owlapi
 
 
-import org.semanticweb.owlapi.model.*
 import org.semanticweb.owlapi.io.XMLUtils
-import java.util.Optional
-import java.util.stream.{Stream => JavaStream}
-import scala.reflect.ClassTag
+import org.semanticweb.owlapi.model.*
 import se.lu.nateko.cp.meta.CpmetaConfig
+
+import java.util.Optional
+import java.util.stream.Stream as JavaStream
+import scala.reflect.ClassTag
 
 extension [T] (opt: Optional[T])
 	def toOption: Option[T] = if(opt.isPresent) Some(opt.get) else None

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/package.scala
@@ -1,13 +1,14 @@
 package se.lu.nateko.cp.meta.utils
 
+import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model.Uri.Path.{Empty, Segment, Slash}
+
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.format.DateTimeFormatter.ISO_DATE_TIME
-import scala.util.{Try, Success, Failure}
-import scala.reflect.ClassTag
-import java.nio.charset.StandardCharsets
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.model.Uri.Path.{Segment, Slash, Empty}
 import scala.collection.mutable.Buffer
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 
 extension [T](inner: Option[T])
 	def toTry(error: => Throwable): Try[T] = inner.map(Success.apply)

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/package.scala
@@ -3,7 +3,6 @@ package se.lu.nateko.cp.meta.utils
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.Path.{Empty, Segment, Slash}
 
-import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 import scala.collection.mutable.Buffer

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Loading.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Loading.scala
@@ -1,13 +1,12 @@
 package se.lu.nateko.cp.meta.utils.rdf4j
 
+import org.eclipse.rdf4j.model.{IRI, Statement}
 import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.repository.sail.SailRepository
-import org.eclipse.rdf4j.sail.memory.MemoryStore
 import org.eclipse.rdf4j.rio.RDFFormat
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.IRI
-import scala.util.Failure
-import scala.util.Try
+import org.eclipse.rdf4j.sail.memory.MemoryStore
+
+import scala.util.{Failure, Try}
 
 object Loading {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Rdf4jIterationIterator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Rdf4jIterationIterator.scala
@@ -1,9 +1,9 @@
 package se.lu.nateko.cp.meta.utils.rdf4j
 
-import scala.collection.AbstractIterator
-
 import org.eclipse.rdf4j.common.iteration.CloseableIteration
 import se.lu.nateko.cp.meta.api.CloseableIterator
+
+import scala.collection.AbstractIterator
 
 class Rdf4jIterationIterator[T](res: CloseableIteration[T], closer: () => Unit = () => ()) extends CloseableIterator.Wrap[T](
 	res.asPlainScalaIterator,

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Rdf4jIterationIterator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Rdf4jIterationIterator.scala
@@ -3,8 +3,6 @@ package se.lu.nateko.cp.meta.utils.rdf4j
 import org.eclipse.rdf4j.common.iteration.CloseableIteration
 import se.lu.nateko.cp.meta.api.CloseableIterator
 
-import scala.collection.AbstractIterator
-
 class Rdf4jIterationIterator[T](res: CloseableIteration[T], closer: () => Unit = () => ()) extends CloseableIterator.Wrap[T](
 	res.asPlainScalaIterator,
 	() =>

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Rdf4jStatement.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/Rdf4jStatement.scala
@@ -1,8 +1,6 @@
 package se.lu.nateko.cp.meta.utils.rdf4j
 
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
+import org.eclipse.rdf4j.model.{IRI, Statement, Value}
 
 object Rdf4jStatement {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/package.scala
@@ -3,28 +3,18 @@ package se.lu.nateko.cp.meta.utils.rdf4j
 import akka.http.scaladsl.model.Uri
 import org.eclipse.rdf4j.common.iteration.CloseableIteration
 import org.eclipse.rdf4j.common.transaction.IsolationLevel
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.Statement
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.XSD
-import org.eclipse.rdf4j.repository.Repository
-import org.eclipse.rdf4j.repository.RepositoryConnection
-import org.eclipse.rdf4j.sail.Sail
-import org.eclipse.rdf4j.sail.SailConnection
-import se.lu.nateko.cp.meta.api.CloseableIterator
-import se.lu.nateko.cp.meta.api.RdfLens
+import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.repository.{Repository, RepositoryConnection}
+import org.eclipse.rdf4j.sail.{Sail, SailConnection}
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
+import se.lu.nateko.cp.meta.api.{CloseableIterator, RdfLens}
 import se.lu.nateko.cp.meta.instanceserver.Rdf4jSailConnection
 
-import java.net.{ URI => JavaUri }
+import java.net.URI as JavaUri
 import java.time.Instant
 import scala.collection.AbstractIterator
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
-import scala.util.Using
+import scala.util.{Failure, Success, Try, Using}
 
 
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/package.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/rdf4j/package.scala
@@ -6,7 +6,7 @@ import org.eclipse.rdf4j.common.transaction.IsolationLevel
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
 import org.eclipse.rdf4j.repository.{Repository, RepositoryConnection}
-import org.eclipse.rdf4j.sail.{Sail, SailConnection}
+import org.eclipse.rdf4j.sail.Sail
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
 import se.lu.nateko.cp.meta.api.{CloseableIterator, RdfLens}
 import se.lu.nateko.cp.meta.instanceserver.Rdf4jSailConnection
@@ -14,7 +14,7 @@ import se.lu.nateko.cp.meta.instanceserver.Rdf4jSailConnection
 import java.net.URI as JavaUri
 import java.time.Instant
 import scala.collection.AbstractIterator
-import scala.util.{Failure, Success, Try, Using}
+import scala.util.{Try, Using}
 
 
 

--- a/src/main/scala/se/lu/nateko/cp/meta/utils/streams/ZipEntryFlow.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/utils/streams/ZipEntryFlow.scala
@@ -1,26 +1,18 @@
 package se.lu.nateko.cp.meta.utils.streams
 
-import java.io.BufferedOutputStream
-import java.util.zip.ZipEntry
-import java.util.zip.ZipOutputStream
+import akka.NotUsed
+import akka.stream.scaladsl.{Flow, Source}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.util.ByteString
 
+import java.io.BufferedOutputStream
+import java.util.zip.{ZipEntry, ZipOutputStream}
 import scala.collection.mutable.Queue
 
 import ZipEntryFlow.ZipEntrySegment
 import ZipEntryFlow.ZipEntryStart
 import ZipEntryFlow.ZipFlowElement
-import akka.NotUsed
-import akka.stream.Attributes
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
-import akka.stream.scaladsl.Flow
-import akka.stream.scaladsl.Source
-import akka.stream.stage.GraphStage
-import akka.stream.stage.GraphStageLogic
-import akka.stream.stage.InHandler
-import akka.stream.stage.OutHandler
-import akka.util.ByteString
 
 object ZipEntryFlow {
 

--- a/src/main/scala/se/lu/nateko/cp/meta/views/LandingPageHelpers.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/views/LandingPageHelpers.scala
@@ -1,24 +1,22 @@
 package se.lu.nateko.cp.meta.views
 
-import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.CpVocab
-import spray.json.*
+import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.node.*
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
-import org.commonmark.ext.autolink.AutolinkExtension
+import se.lu.nateko.cp.doi.meta.Person as DoiMetaPerson
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.core.data.*
+import se.lu.nateko.cp.meta.core.data.JsonSupport.given
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.utils.rdf4j.===
+import se.lu.nateko.cp.meta.utils.urlEncode
+import spray.json.*
 
 import java.net.URI
-import java.time.Instant
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
 import scala.jdk.CollectionConverters.IterableHasAsJava
-import se.lu.nateko.cp.doi.meta.{Person => DoiMetaPerson}
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import se.lu.nateko.cp.meta.utils.urlEncode
-import se.lu.nateko.cp.meta.utils.rdf4j.===
 
 object LandingPageHelpers:
 

--- a/src/main/scala/se/lu/nateko/cp/meta/views/ResourceViewInfo.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/views/ResourceViewInfo.scala
@@ -1,6 +1,7 @@
 package se.lu.nateko.cp.meta.views
 
 import se.lu.nateko.cp.meta.core.data.UriResource
+
 import ResourceViewInfo.PropValue
 
 case class ResourceViewInfo(

--- a/src/main/twirl/views/CollectionLandingPage.scala.html
+++ b/src/main/twirl/views/CollectionLandingPage.scala.html
@@ -2,8 +2,6 @@
 @import se.lu.nateko.cp.meta.core.data.EnvriConfig
 @import se.lu.nateko.cp.meta.core.HandleProxiesConfig
 @import se.lu.nateko.cp.meta.views.LandingPageExtras
-@import se.lu.nateko.cp.meta.views.LandingPageHelpers.getDoiTitle
-@import se.lu.nateko.cp.doi.meta.Title
 @import se.lu.nateko.cp.meta.services.metaexport.SchemaOrg
 @import landpagesnips._
 @import eu.icoscp.envri.Envri

--- a/src/main/twirl/views/DataLandingPage.scala.html
+++ b/src/main/twirl/views/DataLandingPage.scala.html
@@ -1,4 +1,3 @@
-@import java.net.URI
 @import java.time.Instant
 @import se.lu.nateko.cp.meta.core.data.*
 @import se.lu.nateko.cp.meta.core.HandleProxiesConfig

--- a/src/main/twirl/views/landpagesnips/zipContents.scala.html
+++ b/src/main/twirl/views/landpagesnips/zipContents.scala.html
@@ -1,5 +1,4 @@
 @import se.lu.nateko.cp.meta.core.data._
-@import se.lu.nateko.cp.meta.utils.*
 @import java.time.Instant
 
 @(dobj: StaticObject)(implicit conf: EnvriConfig)

--- a/src/test/scala/se/lu/nateko/cp/meta/KmlGeoJsonWorkbench.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/KmlGeoJsonWorkbench.scala
@@ -1,18 +1,13 @@
 package se.lu.nateko.cp.meta
 
-import se.lu.nateko.cp.meta.core.data.{Polygon => GeoPolygon, Position, Circle}
-import com.scalakml.io.{KmzFileReader, KmlPrintWriter}
+import com.scalakml.io.KmzFileReader
 import com.scalakml.kml.*
-import xml.PrettyPrinter
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import spray.json.JsObject
-import java.io.File
-import spray.json.{JsNull, JsValue}
-import se.lu.nateko.cp.meta.core.data.GeoJson
-import se.lu.nateko.cp.meta.core.data.FeatureCollection
+import se.lu.nateko.cp.meta.core.data.{Circle, FeatureCollection, GeoFeature, GeoJson, Polygon as GeoPolygon, Position}
 import se.lu.nateko.cp.meta.core.etcupload.StationId
-import java.net.URI
-import java.net.URL
+import spray.json.{JsNull, JsValue}
+
+import java.io.File
+import java.net.{URI, URL}
 import scala.io.Source
 
 object KmlGeoJsonWorkbench {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/GcpUploadMetaGenerator.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/GcpUploadMetaGenerator.scala
@@ -1,19 +1,15 @@
 package se.lu.nateko.cp.meta.test
 
-import java.io.File
-import java.io.FileOutputStream
-import java.nio.charset.Charset
-
-import scala.io.Source
-
-import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
-
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.utils.rdf4j.toJava
 import eu.icoscp.envri.Envri
 import org.eclipse.rdf4j.model.ValueFactory
+import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
+import se.lu.nateko.cp.meta.services.CpVocab
+import se.lu.nateko.cp.meta.utils.rdf4j.toJava
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, DataObjectDto}
+
+import java.io.{File, FileOutputStream}
+import java.nio.charset.Charset
+import scala.io.Source
 
 /**
  * One-off code to produce upload metadata packages for GCP dataset publication

--- a/src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala
@@ -1,9 +1,9 @@
 package se.lu.nateko.cp.meta.test
 
 import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.meta.onto.{InstOnto, Onto}
+
 import java.net.URI
-import se.lu.nateko.cp.meta.onto.Onto
-import se.lu.nateko.cp.meta.onto.InstOnto
 
 class InstOntoTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/Playground.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/Playground.scala
@@ -1,24 +1,21 @@
 package se.lu.nateko.cp.meta.test
 
-import java.net.URI
-
-import scala.concurrent.Await
-import scala.concurrent.Future
-import scala.concurrent.duration.Duration
-
 import akka.Done
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.cpauth.core.EmailSender
+import se.lu.nateko.cp.meta.ConfigLoader
 import se.lu.nateko.cp.meta.api.HandleNetClient
 import se.lu.nateko.cp.meta.core.sparql.BoundUri
-import se.lu.nateko.cp.meta.test.utils.SparqlClient
-import se.lu.nateko.cp.meta.services.citation.CitationClientImpl
 import se.lu.nateko.cp.meta.ingestion.badm.BadmEntry
-import se.lu.nateko.cp.meta.metaflow.icos.EtcMetaSource
-import eu.icoscp.envri.Envri
+import se.lu.nateko.cp.meta.services.citation.CitationClientImpl
+import se.lu.nateko.cp.meta.test.utils.SparqlClient
+
+import java.net.URI
 import scala.collection.concurrent.TrieMap
-import se.lu.nateko.cp.meta.ConfigLoader
-import se.lu.nateko.cp.cpauth.core.EmailSender
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
 
 
 object Playground {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/TestConfig.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/TestConfig.scala
@@ -1,19 +1,16 @@
 package se.lu.nateko.cp.meta.test
 
-import org.semanticweb.owlapi.apibinding.OWLManager
-import se.lu.nateko.cp.meta.utils.owlapi.*
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.utils.rdf4j.Loading
-import org.semanticweb.owlapi.model.PrefixManager
-import org.semanticweb.owlapi.util.DefaultPrefixManager
-import org.semanticweb.owlapi.model.OWLClass
-import org.semanticweb.owlapi.model.OWLDataProperty
-import org.semanticweb.owlapi.model.OWLObjectProperty
-import org.eclipse.rdf4j.rio.RDFFormat
-import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
-import java.net.URI
 import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.rio.RDFFormat
+import org.semanticweb.owlapi.apibinding.OWLManager
+import org.semanticweb.owlapi.model.{OWLClass, OWLDataProperty, OWLObjectProperty, PrefixManager}
+import org.semanticweb.owlapi.util.DefaultPrefixManager
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, Rdf4jInstanceServer}
+import se.lu.nateko.cp.meta.utils.owlapi.*
+import se.lu.nateko.cp.meta.utils.rdf4j.Loading
+
+import java.net.URI
 
 object TestConfig {
 	val manager = OWLManager.createOWLOntologyManager

--- a/src/test/scala/se/lu/nateko/cp/meta/test/api/AkkaTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/api/AkkaTests.scala
@@ -1,8 +1,9 @@
 package se.lu.nateko.cp.meta.test.api
 
-import org.scalatest.funsuite.AsyncFunSuite
-import org.scalatest.BeforeAndAfterAll
 import akka.actor.ActorSystem
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AsyncFunSuite
+
 import scala.concurrent.Future
 
 class AkkaTests extends AsyncFunSuite with BeforeAndAfterAll:

--- a/src/test/scala/se/lu/nateko/cp/meta/test/api/CustomVocabTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/api/CustomVocabTests.scala
@@ -1,9 +1,9 @@
 package se.lu.nateko.cp.meta.test.api
 
-import org.scalatest.funspec.AnyFunSpec
-import se.lu.nateko.cp.meta.api.{CustomVocab, UriId}
 import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
+import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.meta.api.{CustomVocab, UriId}
 
 class CustomVocabTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/api/HandleNetClientTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/api/HandleNetClientTests.scala
@@ -3,8 +3,8 @@ package se.lu.nateko.cp.meta.test.api
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.HandleNetClient
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum.formatByte
-import java.nio.file.Paths
-import java.nio.file.Files
+
+import java.nio.file.{Files, Paths}
 
 class HandleNetClientTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/icos/EtcMetaSourceTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/icos/EtcMetaSourceTests.scala
@@ -1,11 +1,11 @@
 package se.lu.nateko.cp.meta.test.icos
 
 import org.scalatest.funspec.AnyFunSpec
-import se.lu.nateko.cp.meta.metaflow.InstrumentDeployment
-import se.lu.nateko.cp.meta.core.data.Position
 import se.lu.nateko.cp.meta.api.UriId
+import se.lu.nateko.cp.meta.core.data.{Position, PositionUtil}
+import se.lu.nateko.cp.meta.metaflow.InstrumentDeployment
+
 import java.time.Instant
-import se.lu.nateko.cp.meta.core.data.PositionUtil
 
 class EtcMetaSourceTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/icos/RdfDiffCalcTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/icos/RdfDiffCalcTests.scala
@@ -1,25 +1,21 @@
 package se.lu.nateko.cp.meta.test.icos
 
-import java.net.URI
-
-import org.eclipse.rdf4j.model.Statement
+import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.{Statement, ValueFactory}
+import org.scalatest.GivenWhenThen
 import org.scalatest.funspec.AnyFunSpec
-
-import se.lu.nateko.cp.meta.api.UriId
+import se.lu.nateko.cp.meta.api.{RdfLens, UriId}
 import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, Rdf4jInstanceServer}
 import se.lu.nateko.cp.meta.metaflow.*
 import se.lu.nateko.cp.meta.metaflow.icos.{ATC, AtcConf}
-import se.lu.nateko.cp.meta.utils.rdf4j.{Loading, toRdf}
-import org.scalatest.GivenWhenThen
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import RdfDiffCalcTests.*
 import se.lu.nateko.cp.meta.services.upload.DobjMetaReader
-import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.api.RdfLens
-import org.eclipse.rdf4j.model.ValueFactory
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab}
+import se.lu.nateko.cp.meta.utils.rdf4j.{Loading, toRdf}
+
+import java.net.URI
+
+import RdfDiffCalcTests.*
 
 class RdfDiffCalcTests extends AnyFunSpec with GivenWhenThen:
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/icos/RolesDiffCalcTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/icos/RolesDiffCalcTests.scala
@@ -1,10 +1,10 @@
 package se.lu.nateko.cp.meta.test.icos
 
-import java.time.Instant
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.UriId
-import se.lu.nateko.cp.meta.metaflow.Membership
-import se.lu.nateko.cp.meta.metaflow.RolesDiffCalc
+import se.lu.nateko.cp.meta.metaflow.{Membership, RolesDiffCalc}
+
+import java.time.Instant
 
 class RolesDiffCalcTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/ingestion/badm/BadmTestHelper.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/ingestion/badm/BadmTestHelper.scala
@@ -1,7 +1,8 @@
 package se.lu.nateko.cp.meta.test.ingestion.badm
 
-import se.lu.nateko.cp.meta.ingestion.badm.BadmSchema
 import org.apache.commons.io.IOUtils
+import se.lu.nateko.cp.meta.ingestion.badm.BadmSchema
+
 import java.nio.charset.StandardCharsets
 
 object BadmTestHelper {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/ingestion/badm/ParserTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/ingestion/badm/ParserTests.scala
@@ -1,12 +1,10 @@
 package se.lu.nateko.cp.meta.test.ingestion.badm
 
-import java.time.LocalDate
-import java.time.LocalDateTime
-
 import org.scalatest.funspec.AnyFunSpec
-
 import se.lu.nateko.cp.meta.ingestion.badm.*
 import se.lu.nateko.cp.meta.ingestion.badm.Parser.*
+
+import java.time.{LocalDate, LocalDateTime}
 
 class ParserTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/instanceserver/InstanceServerTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/instanceserver/InstanceServerTests.scala
@@ -1,15 +1,13 @@
 package se.lu.nateko.cp.meta.test.instanceserver
 
-import org.scalatest.funspec.AnyFunSpec
-import se.lu.nateko.cp.meta.persistence.InMemoryRdfLog
-import se.lu.nateko.cp.meta.persistence.RdfUpdateLogIngester
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.instanceserver.LoggingInstanceServer
-import se.lu.nateko.cp.meta.utils.rdf4j.*
+import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.eclipse.rdf4j.repository.sail.SailRepository
 import org.eclipse.rdf4j.sail.memory.MemoryStore
-import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.meta.instanceserver.{LoggingInstanceServer, Rdf4jInstanceServer}
+import se.lu.nateko.cp.meta.persistence.{InMemoryRdfLog, RdfUpdateLogIngester}
+import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 class InstanceServerTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/metaflow/cities/MidLowCostMetaSourceTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/metaflow/cities/MidLowCostMetaSourceTest.scala
@@ -1,10 +1,11 @@
 package se.lu.nateko.cp.meta.test.metaflow.cities
 
 import org.scalatest.funspec.AnyFunSpec
-import java.nio.file.Paths
+import se.lu.nateko.cp.meta.core.data.CountryCode
 import se.lu.nateko.cp.meta.metaflow.cities.MidLowCostMetaSource.parseStation
 import se.lu.nateko.cp.meta.metaflow.icos.AtcMetaSource.parseFromCsv
-import se.lu.nateko.cp.meta.core.data.CountryCode
+
+import java.nio.file.Paths
 
 
 class MidLowCostMetaSourceTest extends AnyFunSpec:

--- a/src/test/scala/se/lu/nateko/cp/meta/test/persistence/RdfUpdateLogIngesterTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/persistence/RdfUpdateLogIngesterTest.scala
@@ -1,13 +1,12 @@
 package se.lu.nateko.cp.meta.test.persistence
 
-import org.scalatest.funspec.AnyFunSpec
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory
-import org.eclipse.rdf4j.model.vocabulary.RDF
-import org.eclipse.rdf4j.model.vocabulary.OWL
-import se.lu.nateko.cp.meta.persistence.RdfUpdateLogIngester
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
 import org.eclipse.rdf4j.common.iteration.Iterations
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory
+import org.eclipse.rdf4j.model.vocabulary.{OWL, RDF}
+import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
+import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
+import se.lu.nateko.cp.meta.persistence.RdfUpdateLogIngester
 
 class RdfUpdateLogIngesterTest extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/persistence/postgres/Manual.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/persistence/postgres/Manual.scala
@@ -1,15 +1,10 @@
 package se.lu.nateko.cp.meta.test.persistence.postgres
-
-import se.lu.nateko.cp.meta.persistence.postgres.PostgresRdfLog
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
-import se.lu.nateko.cp.meta.persistence.postgres.*
-import se.lu.nateko.cp.meta.instanceserver.RdfUpdate
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.LoggingInstanceServer
-import se.lu.nateko.cp.meta.test.TestConfig
-import se.lu.nateko.cp.meta.persistence.RdfUpdateLogIngester
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
 import se.lu.nateko.cp.meta.ConfigLoader
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, LoggingInstanceServer, Rdf4jInstanceServer, RdfUpdate}
+import se.lu.nateko.cp.meta.persistence.RdfUpdateLogIngester
+import se.lu.nateko.cp.meta.persistence.postgres.*
+import se.lu.nateko.cp.meta.test.TestConfig
 
 object Manual {
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/reasoner/HermitBasedReasonerTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/reasoner/HermitBasedReasonerTests.scala
@@ -4,6 +4,7 @@ import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.onto.reasoner.HermitBasedReasoner
 import se.lu.nateko.cp.meta.test.TestConfig
 import se.lu.nateko.cp.meta.utils.owlapi.*
+
 import java.net.URI
 
 class HermitBasedReasonerTests extends AnyFunSpec{

--- a/src/test/scala/se/lu/nateko/cp/meta/test/routes/AlternativePathRouteTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/routes/AlternativePathRouteTest.scala
@@ -1,9 +1,9 @@
 package se.lu.nateko.cp.meta.test.routes
 
-import org.scalatest.funspec.AnyFunSpec
+import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.funspec.AnyFunSpec
 
 class AlternativePathRouteTest extends AnyFunSpec with ScalatestRouteTest{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlFailureHandlerTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlFailureHandlerTest.scala
@@ -2,15 +2,9 @@ package se.lu.nateko.cp.meta.test.services.sparql
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.ContentTypes
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.StatusCode
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCode, StatusCodes}
 import akka.stream.Materializer
-import akka.stream.scaladsl.Keep
-import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.Source
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AsyncFunSpec
@@ -18,8 +12,6 @@ import se.lu.nateko.cp.meta.routes.SparqlRoute
 
 import java.util.concurrent.CancellationException
 import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.concurrent.duration.DurationInt
 
 class SparqlFailureHandlerTest extends AsyncFunSpec with BeforeAndAfterAll{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -1,31 +1,28 @@
 package se.lu.nateko.cp.meta.test.services.sparql
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
-import akka.http.scaladsl.model.HttpHeader
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.CacheDirectives.*
 import akka.http.scaladsl.model.headers.*
+import akka.http.scaladsl.model.headers.CacheDirectives.*
+import akka.http.scaladsl.model.{HttpHeader, StatusCodes}
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.testkit.RouteTestTimeout
-import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.pattern.after
 import eu.icoscp.envri.Envri
 import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
 import se.lu.nateko.cp.meta.SparqlServerConfig
 import se.lu.nateko.cp.meta.api.SparqlQuery
-import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
 import se.lu.nateko.cp.meta.routes.SparqlRoute
 import se.lu.nateko.cp.meta.services.sparql.Rdf4jSparqlServer
+import se.lu.nateko.cp.meta.test.services.sparql.regression.TestDb
 
 import java.net.URI
 import scala.concurrent.Future
 
 import concurrent.duration.DurationInt
-import se.lu.nateko.cp.meta.test.services.sparql.regression.TestDb
-import akka.event.Logging
 
 class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlTests.scala
@@ -1,14 +1,15 @@
 package se.lu.nateko.cp.meta.test.services.sparql
 
-import se.lu.nateko.cp.meta.utils.rdf4j.*
-import org.scalatest.funspec.AnyFunSpec
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory
 import org.eclipse.rdf4j.repository.sail.SailRepository
-import org.eclipse.rdf4j.sail.memory.MemoryStore
-import java.io.StringReader
 import org.eclipse.rdf4j.rio.RDFFormat
-import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
+import org.eclipse.rdf4j.sail.memory.MemoryStore
+import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.api.SparqlQuery
+import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
+import se.lu.nateko.cp.meta.utils.rdf4j.*
+
+import java.io.StringReader
 
 class SparqlTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/GeoIndexTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/GeoIndexTest.scala
@@ -1,29 +1,15 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
 
-import com.opencsv.CSVParserBuilder
-import com.opencsv.CSVReaderBuilder
+import com.opencsv.{CSVParserBuilder, CSVReaderBuilder}
 import org.locationtech.jts.algorithm.hull.ConcaveHull
-import org.locationtech.jts.geom.Coordinate
-import org.locationtech.jts.geom.Envelope
-import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryCollection
-import org.locationtech.jts.geom.Point
+import org.locationtech.jts.geom.{Coordinate, Envelope, Geometry, GeometryCollection, Point}
 import org.locationtech.jts.io.geojson.GeoJsonReader
 import org.roaringbitmap.buffer.MutableRoaringBitmap
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.core.crypto.Md5Sum
-import se.lu.nateko.cp.meta.metaflow.icos.EtcMetaSource.Vars.stationLon
-import se.lu.nateko.cp.meta.services.sparql.magic.DataObjCov
-import se.lu.nateko.cp.meta.services.sparql.magic.DenseCluster
-import se.lu.nateko.cp.meta.services.sparql.magic.GeoEvent
-import se.lu.nateko.cp.meta.services.sparql.magic.GeoIndex
-import se.lu.nateko.cp.meta.services.sparql.magic.GeoLookup
-import se.lu.nateko.cp.meta.services.sparql.magic.JtsGeoFactory
-import se.lu.nateko.cp.meta.services.sparql.magic.SparseCluster
+import se.lu.nateko.cp.meta.services.sparql.magic.{DataObjCov, DenseCluster, GeoEvent, GeoIndex, GeoLookup, JtsGeoFactory, SparseCluster}
 
 import java.io.FileReader
-import scala.collection.mutable.Buffer
-import scala.io.Source
 import scala.jdk.CollectionConverters.IterableHasAsScala
 import scala.language.dynamics
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/LargeScaleDatetimeTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/LargeScaleDatetimeTest.scala
@@ -1,10 +1,11 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
-import java.time.Instant
-import scala.io.Source
+import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.core.algo.DatetimeHierarchicalBitmap
 import se.lu.nateko.cp.meta.core.algo.DatetimeHierarchicalBitmap.DateTimeGeo
-import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap.*
+
+import java.time.Instant
+import scala.io.Source
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class LargeScaleDatetimeTest extends AnyFunSpec{

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/SerializationTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/SerializationTests.scala
@@ -11,20 +11,11 @@ import org.scalatest.funspec.AsyncFunSpec
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap.MinFilter
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.sparql.index.{
-   CategFilter,
-   ContFilter,
-   DataObjectFetch,
-   Station,
-   SubmissionEnd,
-   And,
-   Exists,
-   SortBy,
-   FileName
-}
+import se.lu.nateko.cp.meta.services.sparql.index.{And, CategFilter, ContFilter, DataObjectFetch, Exists, FileName, SortBy, Station, SubmissionEnd}
 import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
 import se.lu.nateko.cp.meta.services.sparql.magic.{CpIndex, IndexHandler}
 import se.lu.nateko.cp.meta.utils.rdf4j.Loading
+
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.time.Instant
 import scala.concurrent.duration.FiniteDuration

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/StringHierarchicalBitmapTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/StringHierarchicalBitmapTests.scala
@@ -1,13 +1,14 @@
 package se.lu.nateko.cp.meta.test.services.sparql.index
 
 import org.scalatest.funspec.AnyFunSpec
-import se.lu.nateko.cp.meta.services.sparql.index.*
-import scala.jdk.CollectionConverters.IteratorHasAsScala
-
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
-import HierarchicalBitmap.*
-import StringHierarchicalBitmap.{StringOrdering => Ord, StringGeo}
+import se.lu.nateko.cp.meta.services.sparql.index.*
+
+import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.Random
+
+import HierarchicalBitmap.*
+import StringHierarchicalBitmap.{StringOrdering as Ord, StringGeo}
 
 class StringHierarchicalBitmapTests extends AnyFunSpec{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/DofPatternFusionTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/DofPatternFusionTests.scala
@@ -1,19 +1,16 @@
 package se.lu.nateko.cp.meta.test.services.sparql.magic.fusion
 
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.Tag
 import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
+import org.eclipse.rdf4j.query.algebra.{Filter as Rdf4jFilter, FunctionCall, TupleExpr, ValueConstant}
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser
-import org.eclipse.rdf4j.query.algebra.{Filter => Rdf4jFilter}
-import org.eclipse.rdf4j.query.algebra.FunctionCall
-import org.eclipse.rdf4j.query.algebra.TupleExpr
-import org.eclipse.rdf4j.query.algebra.ValueConstant
-
+import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
+import org.scalatest.Tag
+import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.core.algo.HierarchicalBitmap
 import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.*
 import se.lu.nateko.cp.meta.services.sparql.index.*
+import se.lu.nateko.cp.meta.services.sparql.magic.fusion.*
+
 import HierarchicalBitmap.{EqualsFilter, IntervalFilter}
 import PatternFinder.*
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/EarlyDobjInitSearch.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/EarlyDobjInitSearch.scala
@@ -1,8 +1,9 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
 import org.eclipse.rdf4j.query.algebra.TupleExpr
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 import se.lu.nateko.cp.meta.services.sparql.index.DobjUri
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 import PatternFinder.*
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/StatementPatternSearch.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/StatementPatternSearch.scala
@@ -1,7 +1,7 @@
 package se.lu.nateko.cp.meta.services.sparql.magic.fusion
 
-import org.eclipse.rdf4j.query.algebra.*
 import org.eclipse.rdf4j.model.IRI
+import org.eclipse.rdf4j.query.algebra.*
 
 object StatementPatternSearch{
 	import PatternFinder.*

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/StatsFetchPatternSearchTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/magic/fusion/StatsFetchPatternSearchTests.scala
@@ -1,21 +1,13 @@
 package se.lu.nateko.cp.meta.test.services.sparql.magic.fusion
 
-import org.scalatest.funspec.AnyFunSpec
-
-import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser
 import org.eclipse.rdf4j.query.algebra.TupleExpr
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser
 import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
-
+import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.services.CpmetaVocab
 import se.lu.nateko.cp.meta.services.sparql.index.*
 import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchPatternSearch.GroupPattern
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.DofPatternSearch
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.DofPatternFusion
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.DobjStatFusion
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.StatsFetchNode
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.DofPatternRewrite
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.ProjectionDofPattern
-import se.lu.nateko.cp.meta.services.sparql.magic.fusion.LeftJoinDofPattern
+import se.lu.nateko.cp.meta.services.sparql.magic.fusion.{DobjStatFusion, DofPatternFusion, DofPatternSearch, StatsFetchNode}
 
 class StatsFetchPatternSearchTests extends AnyFunSpec{
 	private val meta = new CpmetaVocab(new MemValueFactory)

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/QueryTests.scala
@@ -1,8 +1,7 @@
 package se.lu.nateko.cp.meta.test.services.sparql.regression
 
-import org.eclipse.rdf4j.model.Value
-import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.model.vocabulary.XSD
+import org.eclipse.rdf4j.model.{Value, ValueFactory}
 import org.eclipse.rdf4j.query.BindingSet
 import org.scalatest
 import org.scalatest.Informer
@@ -10,8 +9,7 @@ import org.scalatest.compatible.Assertion
 import org.scalatest.funspec.AsyncFunSpec
 import se.lu.nateko.cp.meta.api.CloseableIterator
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.IterableHasAsScala
 
 class QueryTests extends AsyncFunSpec {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/regression/TestDb.scala
@@ -1,8 +1,5 @@
 package se.lu.nateko.cp.meta.test.services.sparql.regression
 
-import java.nio.file.{Files, Path}
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
 import akka.Done
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
@@ -20,6 +17,10 @@ import se.lu.nateko.cp.meta.services.sparql.magic.index.IndexData
 import se.lu.nateko.cp.meta.services.sparql.magic.{CpNotifyingSail, GeoIndexProvider, IndexHandler, StorageSail}
 import se.lu.nateko.cp.meta.utils.async.executeSequentially
 import se.lu.nateko.cp.meta.{LmdbConfig, RdfStorageConfig}
+
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 private val graphIriToFile = Seq(
 	"atmprodcsv",

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/MetadataUpdaterTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/MetadataUpdaterTests.scala
@@ -1,32 +1,21 @@
 package se.lu.nateko.cp.meta.test.services.upload
 
 import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.model.vocabulary.RDF
+import org.eclipse.rdf4j.model.{IRI, Literal, Value, ValueFactory}
 import org.eclipse.rdf4j.repository.sail.SailRepository
 import org.eclipse.rdf4j.sail.memory.MemoryStore
+import org.scalatest.GivenWhenThen
 import org.scalatest.funspec.AsyncFunSpec
-import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.core.data.EnvriConfigs
-import se.lu.nateko.cp.meta.instanceserver.InstanceServer
-import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
-import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.CpmetaVocab
-import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
+import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, Rdf4jInstanceServer}
 import se.lu.nateko.cp.meta.services.upload.ObjMetadataUpdater
+import se.lu.nateko.cp.meta.services.{CpVocab, CpmetaVocab, Rdf4jSparqlRunner}
 import se.lu.nateko.cp.meta.utils.rdf4j.createStringLiteral
 
 import java.net.URI
-import org.eclipse.rdf4j.model.ValueFactory
-import org.eclipse.rdf4j.model.IRI
-import org.eclipse.rdf4j.model.Value
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import org.eclipse.rdf4j.model.Literal
-import org.eclipse.rdf4j.model.vocabulary.RDF
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import org.scalatest.GivenWhenThen
 import java.time.Instant
-import se.lu.nateko.cp.meta.SubmittersConfig
-import se.lu.nateko.cp.meta.DataSubmitterConfig
 
 class MetadataUpdaterTests extends AsyncFunSpec with GivenWhenThen:
 	class Setup(

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/ClusteringExample.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/ClusteringExample.scala
@@ -1,24 +1,12 @@
 package se.lu.nateko.cp.meta.test.services.upload.geocov
-
-import org.locationtech.jts.geom.Coordinate
 import org.locationtech.jts.geom.Geometry
-import org.locationtech.jts.geom.GeometryCollection
-import org.locationtech.jts.geom.GeometryFactory
-import org.locationtech.jts.geom.Point
-import org.locationtech.jts.geom.Polygon
 import org.locationtech.jts.io.WKTReader
-import se.lu.nateko.cp.meta.core.data.FeatureCollection
-import se.lu.nateko.cp.meta.core.data.GeoFeature
-import se.lu.nateko.cp.meta.core.data.GeoJson
-import se.lu.nateko.cp.meta.core.data.PositionUtil.average
+import se.lu.nateko.cp.meta.core.data.{FeatureCollection, GeoFeature, GeoJson}
 import se.lu.nateko.cp.meta.services.sparql.magic.JtsGeoFactory
-import se.lu.nateko.cp.meta.services.upload.geocov.GeoCovMerger.mergeIntersecting
-import se.lu.nateko.cp.meta.services.upload.geocov.GeoCovMerger.representativeCoverage
+import se.lu.nateko.cp.meta.services.upload.geocov.GeoCovMerger.{mergeIntersecting, representativeCoverage}
 import se.lu.nateko.cp.meta.services.upload.geocov.LabeledJtsGeo
 
-import java.nio.file.Files
-import java.nio.file.Paths
-import scala.collection.mutable.ArrayBuffer
+import java.nio.file.{Files, Paths}
 
 
 object ClusteringExample:

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/GeoCovMergerTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/GeoCovMergerTests.scala
@@ -1,13 +1,11 @@
 package se.lu.nateko.cp.meta.test.services.upload.geocov
 
-import org.locationtech.jts.geom.Coordinate
-import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.geom.{Coordinate, Geometry}
 import org.locationtech.jts.io.WKTReader
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.services.sparql.magic.JtsGeoFactory
 import se.lu.nateko.cp.meta.services.upload.geocov.GeoCovMerger.*
 import se.lu.nateko.cp.meta.services.upload.geocov.LabeledJtsGeo
-import se.lu.nateko.cp.meta.test.services.upload.geocov.TestGeometries.*
 
 import ClusteringExample.convertStringsToJTS
 import TestGeometries.*

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/TestGeoFeatures.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/TestGeoFeatures.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.{HttpRequest, MediaTypes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import se.lu.nateko.cp.cpauth.core.JsonSupport.immSeqFormat
 import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.meta.core.data.{DataObject, PlainStaticObject, StaticCollection, *}
+import se.lu.nateko.cp.meta.core.data.{DataObject, PlainStaticObject, StaticCollection, GeoFeature, GeoTrack, FeatureCollection, Position, Circle, Polygon}
 import se.lu.nateko.cp.meta.utils.async.traverseFut
 import spray.json.RootJsonFormat
 import spray.json.given

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/TestGeoFeatures.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/upload/geocov/TestGeoFeatures.scala
@@ -3,33 +3,22 @@ package se.lu.nateko.cp.meta.test.services.upload.geocov
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.MediaTypes
 import akka.http.scaladsl.model.headers.Accept
+import akka.http.scaladsl.model.{HttpRequest, MediaTypes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import se.lu.nateko.cp.cpauth.core.JsonSupport.immSeqFormat
-import se.lu.nateko.cp.meta.core.data.*
-import se.lu.nateko.cp.meta.core.data.DataObject
 import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import se.lu.nateko.cp.meta.core.data.PlainStaticObject
-import se.lu.nateko.cp.meta.core.data.StaticCollection
+import se.lu.nateko.cp.meta.core.data.{DataObject, PlainStaticObject, StaticCollection, *}
 import se.lu.nateko.cp.meta.utils.async.traverseFut
 import spray.json.RootJsonFormat
 import spray.json.given
 
-import java.io.BufferedReader
-import java.io.BufferedWriter
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
+import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter}
 import java.net.URI
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.StandardOpenOption.CREATE
-import java.nio.file.StandardOpenOption.TRUNCATE_EXISTING
-import java.nio.file.StandardOpenOption.WRITE
-import java.util.zip.GZIPInputStream
-import java.util.zip.GZIPOutputStream
+import java.nio.file.StandardOpenOption.{CREATE, TRUNCATE_EXISTING, WRITE}
+import java.nio.file.{Files, Paths}
+import java.util.zip.{GZIPInputStream, GZIPOutputStream}
 import scala.concurrent.Future
 import scala.util.Using
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/utils/JavaTaskCancellationTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/utils/JavaTaskCancellationTests.scala
@@ -1,10 +1,9 @@
 package se.lu.nateko.cp.meta.test.utils
 
-import org.scalatest.funsuite.AnyFunSuite
-import java.util.concurrent.Callable
-import java.util.concurrent.CancellationException
-import java.util.concurrent.ScheduledThreadPoolExecutor
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.concurrent.{Callable, CancellationException, ScheduledThreadPoolExecutor}
 
 class JavaTaskCancellationTests extends AnyFunSuite with BeforeAndAfterAll{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/utils/SparqlClient.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/utils/SparqlClient.scala
@@ -2,16 +2,16 @@ package se.lu.nateko.cp.meta.test.utils
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.*
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
+import akka.http.scaladsl.model.*
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import scala.concurrent.Future
-import se.lu.nateko.cp.meta.core.sparql.SparqlSelectResult
 import se.lu.nateko.cp.meta.core.sparql.JsonSupport.given
+import se.lu.nateko.cp.meta.core.sparql.SparqlSelectResult
+
 import java.net.URI
-import scala.util.Success
-import scala.util.Failure
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 class SparqlClient(url: URI)(using system: ActorSystem) {
 	import system.dispatcher

--- a/src/test/scala/se/lu/nateko/cp/meta/test/utils/UrlEncodeDecodeTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/utils/UrlEncodeDecodeTests.scala
@@ -1,7 +1,7 @@
 package se.lu.nateko.cp.meta.test.utils
 
-import se.lu.nateko.cp.meta.utils.{urlDecode, urlEncode}
 import org.scalatest.funsuite.AnyFunSuite
+import se.lu.nateko.cp.meta.utils.{urlDecode, urlEncode}
 
 class UrlEncodeDecodeTests extends AnyFunSuite{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/utils/rdf4j/EnrichedUriTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/utils/rdf4j/EnrichedUriTests.scala
@@ -1,10 +1,11 @@
 package se.lu.nateko.cp.meta.test.utils.rdf4j
 
+import org.eclipse.rdf4j.model.ValueFactory
 import org.eclipse.rdf4j.sail.memory.model.MemValueFactory
 import org.scalatest.funsuite.AnyFunSuite
-import java.net.URI
 import se.lu.nateko.cp.meta.utils.rdf4j.*
-import org.eclipse.rdf4j.model.ValueFactory
+
+import java.net.URI
 
 class EnrichedUriTests extends AnyFunSuite {
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/utils/streams/CachedSourceTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/utils/streams/CachedSourceTests.scala
@@ -1,12 +1,11 @@
 package se.lu.nateko.cp.meta.test.utils.streams
 
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatest.BeforeAndAfterAll
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Sink
-import akka.stream.scaladsl.Source
 import akka.stream.OverflowStrategy
-import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+
 import scala.util.Success
 
 class CachedSourceTests extends AnyFunSuite with BeforeAndAfterAll{

--- a/src/test/scala/se/lu/nateko/cp/meta/test/utils/streams/ZipEntryFlowTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/utils/streams/ZipEntryFlowTests.scala
@@ -1,20 +1,17 @@
 package se.lu.nateko.cp.meta.test.utils.streams
 
-import scala.language.postfixOps
-
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
-
 import akka.actor.ActorSystem
 import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ByteString
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import se.lu.nateko.cp.meta.utils.streams.ZipEntryFlow
 
 import scala.collection.immutable.Iterable
-import akka.util.ByteString
-import akka.stream.scaladsl.Source
-import se.lu.nateko.cp.meta.utils.streams.ZipEntryFlow
-import akka.stream.scaladsl.Sink
 import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import scala.language.postfixOps
 
 class ZipEntryFlowTests extends AnyFunSuite with BeforeAndAfterAll{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/AtcCollMaker.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/AtcCollMaker.scala
@@ -1,21 +1,17 @@
 package se.lu.nateko.cp.meta.upload
 
+import akka.Done
 import se.lu.nateko.cp.doi.*
 import se.lu.nateko.cp.doi.meta.*
-import se.lu.nateko.cp.meta.core.data.DataObject
-import scala.concurrent.ExecutionContext
-import se.lu.nateko.cp.meta.core.sparql.SparqlSelectResult
-import java.net.URI
-import se.lu.nateko.cp.meta.core.sparql.BoundLiteral
-import se.lu.nateko.cp.meta.core.sparql.BoundUri
 import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.core.data.Station
-import se.lu.nateko.cp.meta.core.data.Person
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import scala.concurrent.Future
-import akka.Done
-import se.lu.nateko.cp.meta.utils.async.*
+import se.lu.nateko.cp.meta.core.data.{DataObject, Person, Station}
+import se.lu.nateko.cp.meta.core.sparql.{BoundUri, SparqlSelectResult}
 import se.lu.nateko.cp.meta.services.upload.UploadService
+import se.lu.nateko.cp.meta.utils.async.*
+
+import java.net.URI
+import scala.concurrent.{ExecutionContext, Future}
 
 class AtcCollMaker(maker: DoiMaker, uploader: CpUploadClient)(implicit ctxt: ExecutionContext) {
 	import AtcCollMaker.*

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/CpUploadClient.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/CpUploadClient.scala
@@ -1,38 +1,27 @@
 package se.lu.nateko.cp.meta.upload
 
-import scala.concurrent.Future
-import scala.collection.immutable.Seq
-import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.RequestEntity
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpMethods
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.model.headers.Cookie
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
-import java.nio.file.Path
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.ContentTypes
-import akka.stream.scaladsl.FileIO
-import akka.stream.scaladsl.Sink
-import akka.http.scaladsl.model.headers.Host
-import spray.json.RootJsonFormat
-import se.lu.nateko.cp.meta.utils.akkahttp.responseToDone
-import se.lu.nateko.cp.meta.utils.async.executeSequentially
+import akka.Done
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.Done
-import akka.stream.Materializer
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.UploadDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.core.data.JsonSupport.given
-import java.net.URI
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.headers.{Accept, Cookie, Host}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest, MediaTypes, RequestEntity, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
+import akka.stream.scaladsl.{FileIO, Sink}
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.DataObject
-import akka.http.scaladsl.model.headers.Accept
-import akka.http.scaladsl.model.MediaTypes
+import se.lu.nateko.cp.meta.core.data.JsonSupport.given
+import se.lu.nateko.cp.meta.utils.akkahttp.responseToDone
+import se.lu.nateko.cp.meta.utils.async.executeSequentially
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, ObjectUploadDto, StaticCollectionDto, UploadDto}
+import spray.json.RootJsonFormat
+
+import java.net.URI
+import java.nio.file.Path
+import scala.collection.immutable.Seq
+import scala.concurrent.Future
 
 class CpUploadClient(conf: CpUploadClient.Config)(implicit val system: ActorSystem) extends CpmetaJsonProtocol{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/DigestFlow.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/DigestFlow.scala
@@ -1,22 +1,14 @@
 package se.lu.nateko.cp.meta.upload
 
-import java.security.MessageDigest
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.util.Success
-import akka.stream.Attributes
-import akka.stream.FlowShape
-import akka.stream.Inlet
-import akka.stream.Outlet
 import akka.stream.scaladsl.Flow
-import akka.stream.stage.GraphStageLogic
-import akka.stream.stage.GraphStageWithMaterializedValue
-import akka.stream.stage.InHandler
-import akka.stream.stage.OutHandler
+import akka.stream.stage.{GraphStageLogic, GraphStageWithMaterializedValue, InHandler, OutHandler}
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
 import akka.util.ByteString
-import se.lu.nateko.cp.meta.core.crypto.Md5Sum
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import scala.util.Failure
+import se.lu.nateko.cp.meta.core.crypto.{Md5Sum, Sha256Sum}
+
+import java.security.MessageDigest
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success}
 
 object DigestFlow{
 

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/DoiMaker.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/DoiMaker.scala
@@ -3,19 +3,14 @@ package se.lu.nateko.cp.meta.upload
 import akka.Done
 import akka.actor.ActorSystem
 import se.lu.nateko.cp.doi.*
-import se.lu.nateko.cp.doi.core.DoiClient
-import se.lu.nateko.cp.doi.core.DoiClientConfig
-import se.lu.nateko.cp.doi.core.PlainJavaDoiHttp
+import se.lu.nateko.cp.doi.core.{DoiClient, DoiClientConfig, DoiMemberConfig, PlainJavaDoiHttp}
 import se.lu.nateko.cp.doi.meta.*
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.upload.UploadService
 import se.lu.nateko.cp.meta.utils.async.executeSequentially
 
 import java.net.URI
 import scala.concurrent.Future
-import scala.util.Try
-import se.lu.nateko.cp.doi.core.DoiMemberConfig
 
 class DoiMaker(password: String)(implicit val system: ActorSystem){
 

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/L3UpdateWorkbench.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/L3UpdateWorkbench.scala
@@ -1,25 +1,15 @@
 package se.lu.nateko.cp.meta.upload
 
+import akka.Done
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.utils.async.executeSequentially
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, DataObjectDto}
+
 import java.net.URI
 import scala.concurrent.Future
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.CpmetaJsonProtocol
-import se.lu.nateko.cp.meta.utils.async.{ok, error, executeSequentially}
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport.*
 import scala.io.Source
-import scala.util.Success
-import scala.util.Failure
-import spray.json.*
-import akka.Done
-import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.HttpMethods
-import akka.http.scaladsl.model.RequestEntity
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import scala.util.{Failure, Success}
 
 object L3UpdateWorkbench extends CpmetaJsonProtocol{
 	given system: ActorSystem = ActorSystem("l3update_workbench")

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/SparqlHelper.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/SparqlHelper.scala
@@ -1,10 +1,11 @@
 package se.lu.nateko.cp.meta.upload
 
-import se.lu.nateko.cp.doi.meta.*
-import scala.concurrent.Future
 import akka.actor.ActorSystem
+import se.lu.nateko.cp.doi.meta.*
 import se.lu.nateko.cp.meta.test.utils.SparqlClient
+
 import java.net.URI
+import scala.concurrent.Future
 
 class SparqlHelper(endpoint: URI)(implicit system: ActorSystem){
 	import se.lu.nateko.cp.meta.core.sparql.*

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/UploadWorkbench.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/UploadWorkbench.scala
@@ -1,22 +1,19 @@
 package se.lu.nateko.cp.meta.upload
 
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import java.net.URI
-import akka.actor.ActorSystem
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import scala.concurrent.Await
-import se.lu.nateko.cp.meta.upload.drought.DroughtDoiMaker
-import scala.concurrent.duration.DurationInt
-import se.lu.nateko.cp.doi.*
-import se.lu.nateko.cp.meta.services.citation.CitationClientImpl
-import se.lu.nateko.cp.meta.CitationConfig
-import akka.stream.Materializer
-import se.lu.nateko.cp.meta.utils.async.executeSequentially
-import scala.concurrent.Future
 import akka.Done
-import se.lu.nateko.cp.meta.upload.drought.DroughtDoiMaker2
-import se.lu.nateko.cp.meta.upload.drought.FluxdataUpload
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import se.lu.nateko.cp.doi.*
+import se.lu.nateko.cp.meta.StaticCollectionDto
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.services.citation.CitationClientImpl
+import se.lu.nateko.cp.meta.upload.drought.{DroughtDoiMaker, DroughtDoiMaker2, FluxdataUpload}
+import se.lu.nateko.cp.meta.utils.async.executeSequentially
+
+import java.net.URI
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
 
 object UploadWorkbench{
 	given system: ActorSystem = ActorSystem("upload_workbench")

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtDoiMaker.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtDoiMaker.scala
@@ -1,16 +1,14 @@
 package se.lu.nateko.cp.meta.upload.drought
-
-import se.lu.nateko.cp.doi.core.DoiClient
+import akka.Done
 import se.lu.nateko.cp.doi.*
 import se.lu.nateko.cp.doi.meta.*
-import scala.concurrent.Future
 import se.lu.nateko.cp.meta.core.etcupload.StationId
-import java.net.URI
-import scala.concurrent.ExecutionContext
 import se.lu.nateko.cp.meta.upload.*
 import se.lu.nateko.cp.meta.utils.async.executeSequentially
-import akka.Done
+
+import java.net.URI
 import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
 
 
 class DroughtDoiMaker(maker: DoiMaker, peeps: Map[URI, PersonalName], names: Map[URI, String])(implicit ctxt: ExecutionContext){

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtDoiMaker2.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtDoiMaker2.scala
@@ -1,18 +1,14 @@
 package se.lu.nateko.cp.meta.upload.drought
-
-import se.lu.nateko.cp.doi.core.DoiClient
+import akka.Done
 import se.lu.nateko.cp.doi.*
 import se.lu.nateko.cp.doi.meta.*
-import scala.concurrent.Future
-import se.lu.nateko.cp.meta.core.etcupload.StationId
-import java.net.URI
-import scala.concurrent.ExecutionContext
-import se.lu.nateko.cp.meta.upload.*
-import se.lu.nateko.cp.meta.utils.async.executeSequentially
-import akka.Done
-import java.time.Instant
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.services.citation.CitationClient
+import se.lu.nateko.cp.meta.upload.*
+import se.lu.nateko.cp.meta.utils.async.executeSequentially
+
+import java.time.Instant
+import scala.concurrent.{ExecutionContext, Future}
 
 
 class DroughtDoiMaker2(maker: DoiMaker, citer: CitationClient)(implicit ctxt: ExecutionContext){

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtMeta2.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtMeta2.scala
@@ -1,22 +1,16 @@
 package se.lu.nateko.cp.meta.upload.drought
 
-import com.opencsv.CSVParserBuilder
-import com.opencsv.CSVReaderBuilder
+import com.opencsv.{CSVParserBuilder, CSVReaderBuilder}
 import se.lu.nateko.cp.doi.Doi
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
 import se.lu.nateko.cp.meta.core.data.TimeInterval
 import se.lu.nateko.cp.meta.services.CpVocab
-import se.lu.nateko.cp.meta.services.citation.CitationClient
-import se.lu.nateko.cp.meta.services.citation.CitationStyle
+import se.lu.nateko.cp.meta.services.citation.{CitationClient, CitationStyle}
 
-import java.io.File
-import java.io.FileReader
+import java.io.{File, FileReader}
 import java.net.URI
-import java.time.Instant
-import java.time.LocalDate
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.io.Source
+import java.time.{Instant, LocalDate}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.Using
 

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtUpload.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/drought/DroughtUpload.scala
@@ -1,22 +1,18 @@
 package se.lu.nateko.cp.meta.upload.drought
 
-import scala.concurrent.Future
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import java.net.URI
-import java.nio.file.Path
-import se.lu.nateko.cp.meta.core.data.TimeInterval
 import akka.Done
-import java.io.InputStreamReader
 import com.opencsv.CSVReader
-import java.nio.file.Paths
-import scala.jdk.CollectionConverters.IteratorHasAsScala
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.DataProductionDto
-import se.lu.nateko.cp.meta.StationTimeSeriesDto
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.upload.*
 import se.lu.nateko.cp.doi.*
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.core.data.TimeInterval
+import se.lu.nateko.cp.meta.upload.*
+import se.lu.nateko.cp.meta.{DataObjectDto, DataProductionDto, ObjectUploadDto, StaticCollectionDto, StationTimeSeriesDto}
+
+import java.io.InputStreamReader
+import java.net.URI
+import java.nio.file.{Path, Paths}
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 
 object DroughtUpload{

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/drought/FluxMeta.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/drought/FluxMeta.scala
@@ -1,11 +1,12 @@
 package se.lu.nateko.cp.meta.upload.drought
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import java.net.URI
 import se.lu.nateko.cp.meta.core.etcupload.StationId
-import java.time.Instant
 import se.lu.nateko.cp.meta.upload.CpUploadClient
+
+import java.net.URI
+import java.nio.file.{Files, Path}
+import java.time.Instant
 import java.util.zip.ZipFile
-import java.nio.file.{Path, Files}
 import scala.jdk.CollectionConverters.EnumerationHasAsScala
 
 

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/drought/FluxdataUpload.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/drought/FluxdataUpload.scala
@@ -1,30 +1,18 @@
 package se.lu.nateko.cp.meta.upload.drought
 
-import scala.concurrent.Future
-import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
-import java.net.URI
-import java.nio.file.Path
-import se.lu.nateko.cp.meta.core.data.TimeInterval
-import akka.Done
-import java.io.InputStreamReader
-import com.opencsv.CSVReader
-import java.nio.file.Paths
-import scala.jdk.CollectionConverters.*
-import se.lu.nateko.cp.meta.StaticCollectionDto
-import se.lu.nateko.cp.meta.ObjectUploadDto
-import se.lu.nateko.cp.meta.DataProductionDto
-import se.lu.nateko.cp.meta.StationTimeSeriesDto
-import se.lu.nateko.cp.meta.DataObjectDto
-import se.lu.nateko.cp.meta.upload.*
 import se.lu.nateko.cp.doi.*
+import se.lu.nateko.cp.meta.core.data.TimeInterval
 import se.lu.nateko.cp.meta.services.citation.CitationClient
-import scala.concurrent.ExecutionContext
-import java.nio.file.Files
+import se.lu.nateko.cp.meta.upload.*
 import se.lu.nateko.cp.meta.upload.CpUploadClient.FileInfo
-import java.util.zip.ZipFile
+import se.lu.nateko.cp.meta.{DataObjectDto, DataProductionDto, ObjectUploadDto, ReferencesDto, StaticCollectionDto, StationTimeSeriesDto}
+
+import java.net.URI
+import java.nio.file.{Files, Path, Paths}
 import java.time.Instant
-import se.lu.nateko.cp.meta.core.data.References
-import se.lu.nateko.cp.meta.ReferencesDto
+import java.util.zip.ZipFile
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters.*
 
 
 object FluxdataUpload{

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
@@ -8,9 +8,7 @@ import scala.scalajs.js.URIUtils.encodeURIComponent
 import scala.scalajs.js.Thenable.Implicits.thenable2future
 import org.scalajs.dom.File
 import org.scalajs.dom.fetch
-import org.scalajs.dom.XMLHttpRequest
 import org.scalajs.dom.RequestInit
-import org.scalajs.dom.Headers
 import org.scalajs.dom.RequestCredentials
 import org.scalajs.dom.Response
 import org.scalajs.dom.HttpMethod
@@ -20,7 +18,6 @@ import se.lu.nateko.cp.meta.{SubmitterProfile, UploadDto}
 import se.lu.nateko.cp.meta.core.data.EnvriConfig
 import se.lu.nateko.cp.doi.Doi
 import scala.scalajs.js.Dictionary
-import se.lu.nateko.cp.meta.OntoConstants.FormatUris.*
 import scala.language.strictEquality
 
 object Backend {

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/UploadApp.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/UploadApp.scala
@@ -1,16 +1,12 @@
 package se.lu.nateko.cp.meta.upload
 
 import org.scalajs.dom
-import org.scalajs.dom.document
 import org.scalajs.dom.html
 import se.lu.nateko.cp.meta.UploadDto
 import se.lu.nateko.cp.meta.core.data.EnvriConfig
-import se.lu.nateko.cp.meta.upload.formcomponents.Button
 import se.lu.nateko.cp.meta.upload.formcomponents.HtmlElements
 import se.lu.nateko.cp.meta.upload.formcomponents.ProgressBar
 
-import java.net.URI
-import scala.concurrent.Future
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scala.scalajs.js.URIUtils
 import scala.concurrent.Future

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Utils.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Utils.scala
@@ -5,7 +5,6 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import org.scalajs.dom.{document, html}
-import org.scalajs.dom.ext.*
 import scala.scalajs.js
 import org.scalajs.dom
 import org.scalajs.dom.Element

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/FormComponents.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/FormComponents.scala
@@ -6,7 +6,6 @@ import scala.util.{ Success, Try, Failure }
 
 import org.scalajs.dom
 import org.scalajs.dom.html
-import org.scalajs.dom.ext.*
 
 import se.lu.nateko.cp.meta.upload.Utils.*
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/DataPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/DataPanel.scala
@@ -11,7 +11,6 @@ import se.lu.nateko.cp.meta.SubmitterProfile
 import UploadApp.whenDone
 import java.net.URI
 import java.time.Instant
-import org.scalajs.dom.html
 import eu.icoscp.envri.Envri
 
 

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/GeoCoverageSelector.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/GeoCoverageSelector.scala
@@ -14,7 +14,6 @@ import se.lu.nateko.cp.meta.upload.formcomponents.JsonInput
 import se.lu.nateko.cp.meta.upload.formcomponents.TextOptInput
 
 import java.net.URI
-import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 import se.lu.nateko.cp.meta.GeoCoverage

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/PanelSubform.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/PanelSubform.scala
@@ -4,7 +4,6 @@ import se.lu.nateko.cp.meta.upload.formcomponents.HtmlElements
 import se.lu.nateko.cp.meta.upload.*
 import eu.icoscp.envri.Envri
 
-import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scala.concurrent.Future
 
 abstract class PanelSubform(selector: String)(using bus: PubSubBus) {

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/ProductionPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/ProductionPanel.scala
@@ -1,13 +1,9 @@
 package se.lu.nateko.cp.meta.upload.subforms
 
-
-import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-
 import scala.util.{Try, Success}
 
 import se.lu.nateko.cp.meta.upload.*
 import se.lu.nateko.cp.meta.{UploadDto, DataObjectDto, DataProductionDto}
-import se.lu.nateko.cp.meta.upload.formcomponents.HtmlElements
 
 import formcomponents.*
 import Utils.*


### PR DESCRIPTION
This was automatically done by adding `scalafix` as in the diff below and running `scalafixAll` in `sbt`.
Source: https://scalacenter.github.io/scalafix/docs/users/installation.html

~~This PR fixes all unused imports in `.scala` files, however many of the warnings in `.scala.html` files are false, hence we cannot turn on `-Werror` yet, unfortunately.
Having `-Wunused:imports` is still useful though, since we will now get warnings from `metals` when working in `.scala` files.~~
This was fixed by: https://github.com/ICOS-Carbon-Portal/meta/pull/290/commits/8971fff5243a2e2f3dcca7d79f70310763226e91

```diff
diff --git a/build.sbt b/build.sbt
index 4bfed609..bfa21fcd 100644
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ import sbt.librarymanagement.InclExclRule
 Global / onChangedBuildSource := ReloadOnSourceChanges
 ThisBuild / organization := "se.lu.nateko.cp"
 ThisBuild / scalaVersion := "3.3.4"
+ThisBuild / scalaVersion := "3.3.4"
+ThisBuild / semanticdbEnabled := true
 
 val commonScalacOptions = Seq(
 	"-encoding", "UTF-8",
diff --git a/project/plugins.sbt b/project/plugins.sbt
index add711ea..2e8ec502 100644
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,5 @@ addSbtPlugin("se.lu.nateko.cp" % "icoscp-sbt-deploy" % "0.4.0")
 addSbtPlugin("eu.icoscp" % "icoscp-sbt-codegen" % "0.3.2")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.0")
```

and this `.scalafix.conf` configuration:
```
rules = [
  OrganizeImports,
  RemoveUnused
]

OrganizeImports.groupedImports = Merge
OrganizeImports.removeUnused = true
OrganizeImports.targetDialect = Scala3
```