### PR TITLE
Reduce visibility of IndexData objects

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/Main.scala
@@ -34,7 +34,7 @@ object Main extends App with CpmetaJsonProtocol{
 			log.info("Trying to restore SPARQL magic index...")
 			val indexDataFut = IndexHandler.restore()
 			indexDataFut.foreach{idx =>
-				log.info(s"SPARQL magic index restored successfully (${idx.objs.length} objects)")
+				log.info(s"SPARQL magic index restored successfully (${idx.objectCount} objects)")
 				IndexHandler.dropStorage()
 			}
 			indexDataFut.map(Option(_)).recover{

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
@@ -46,7 +46,7 @@ class CpIndex(sail: Sail, geo: Future[GeoIndex], data: IndexData) extends ReadWr
 	private val log = LoggerFactory.getLogger(getClass())
 	private val filtering = Filtering(data, geo)
 
-	import data.{contMap, stats, objs, initOk, idLookup}
+	import data.{contMap, stats, initOk}
 	def this(sail: Sail, geo: Future[GeoIndex], nObjects: Int = 10000) = {
 		this(sail, geo, IndexData(nObjects)())
 		//Mass-import of the statistics data
@@ -86,7 +86,7 @@ class CpIndex(sail: Sail, geo: Future[GeoIndex], data: IndexData) extends ReadWr
 
 	private val queue = new ArrayBlockingQueue[RdfUpdate](UpdateQueueSize)
 
-	def size: Int = objs.length
+	def size: Int = data.objectCount
 	def serializableData: Serializable = data
 
 	def fetch(req: DataObjectFetch): Iterator[ObjInfo] = readLocked{
@@ -101,7 +101,7 @@ class CpIndex(sail: Sail, geo: Future[GeoIndex], data: IndexData) extends ReadWr
 				data.bitmap(prop).iterateSorted(Some(filter), req.offset, descending)
 		}
 		//println(s"Fetch from CpIndex complete in ${System.currentTimeMillis - start} ms")
-		idxIter.map(objs.apply)
+		idxIter.map(data.getObject)
 	}
 
 
@@ -122,7 +122,7 @@ class CpIndex(sail: Sail, geo: Future[GeoIndex], data: IndexData) extends ReadWr
 		}
 	}
 
-	def lookupObject(hash: Sha256Sum): Option[ObjInfo] = idLookup.get(hash).map(objs.apply)
+	def lookupObject = data.lookupObject
 
 	def getObjEntry = data.getObjEntry
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -27,12 +27,12 @@ class IndexDataTest extends AnyFunSuite {
 
 		// Insert hasName triple
 		data.processUpdate(statement, true, vocab)
-		assert(data.objs.length == 1)
+		assert(data.objectCount == 1)
 		assert(data.getObjEntry(hash).fileName === Some("test name"))
 
 		// Remove it
 		data.processUpdate(statement, false, vocab)
 		assert(data.getObjEntry(hash).fileName === None)
-		assert(data.objs.length == 1)
+		assert(data.objectCount == 1)
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/SerializationTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/SerializationTests.scala
@@ -128,7 +128,7 @@ class SerializationTests extends AsyncFunSpec{
 		}
 
 		origAndCopy("contain expected hashsums", Set(etcObjHash, droughtObjHash)){
-			toData.andThen(_.objs.map(_.hash).toSet)
+			toData.andThen(_.copyObjects().map(_.hash).toSet)
 		}
 
 		origAndCopy("correctly filters by station", 1){idx =>


### PR DESCRIPTION
This removes external access to the mutable array of `ObjEntry` instances inside `IndexData`, and adds a few new methods covering the existing use-cases without allowing mutation of the array.

The main motivation is that `IndexData` relies on being the only one creating and inserting new `ObjEntry` instances, and specifically because we use the length of the array for the next id here: https://github.com/ICOS-Carbon-Portal/meta/blob/master/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala#L298