### PR TITLE
Improve robustness and indexing speed of associated keywords

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/services/CpmetaVocab.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/CpmetaVocab.scala
@@ -39,6 +39,7 @@ class CpmetaVocab (val factory: ValueFactory) extends CustomVocab { top =>
 	val dataObjectClass = getRelativeRaw("DataObject")
 	val docObjectClass = getRelativeRaw("DocumentObject")
 	val dataObjectSpecClass = getRelativeRaw("DataObjectSpec")
+	val simpleObjectSpecClass = getRelativeRaw("SimpleObjectSpec")
 	val datasetSpecClass = getRelativeRaw("DatasetSpec")
 	val tabularDatasetSpecClass = getRelativeRaw("TabularDatasetSpec")
 	val plainCollectionClass = getRelativeRaw("PlainCollection")

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
@@ -26,7 +26,8 @@ import se.lu.nateko.cp.meta.services.sparql.index.{
 	FileSizeHierarchicalBitmap,
 	Property,
 	SamplingHeightHierarchicalBitmap,
-	StringHierarchicalBitmap
+	StringHierarchicalBitmap,
+	Spec
 }
 import se.lu.nateko.cp.meta.services.sparql.magic.index.{
 	DataEndGeo,
@@ -179,7 +180,7 @@ object IndexDataSerializer extends Serializer[IndexData]:
 
 		registerIriSerializer(kryo, IriSerializer)
 
-		val iriIndex = buildIriIndex(data.objs)
+		val iriIndex = buildIriIndex(data.objs, data.categoryKeys(Spec))
 		kryo.writeObject(output, iriIndex)
 
 		val prefixIndex = buildPrefixIndex(data.objs)
@@ -217,7 +218,7 @@ object IndexDataSerializer extends Serializer[IndexData]:
 
 		GeoSerializer.register(kryo, objs)
 
-		val keywordsToSpecs = 
+		val keywordsToSpecs =
 			readObj(classOf[AnyRefMap[String, Array[String]]])
 				.map((kw, iriStrings) => (kw, iriStrings.map(Values.iri).toSet))
 
@@ -245,13 +246,16 @@ object IndexDataSerializer extends Serializer[IndexData]:
 		.distinct
 		.toArray
 
-	private def buildIriIndex(objs: ArrayBuffer[ObjEntry]): Array[IRI] = objs
-		.iterator
-		.flatMap: o =>
-			Iterator(o.spec, o.submitter, o.station, o.site)
-		.filter(_ != null)
-		.distinct
-		.toArray
+	private def buildIriIndex(objs: ArrayBuffer[ObjEntry], specs: Iterable[IRI]): Array[IRI] = {
+		val objectIRIs =
+			objs
+				.iterator
+				.flatMap(o => Iterator(o.submitter, o.station, o.site))
+				.filter(_ != null)
+				.distinct
+
+		objectIRIs.concat(specs.iterator).toArray
+	}
 
 end IndexDataSerializer
 
@@ -324,7 +328,7 @@ object IriSerializer extends Serializer[IRI]:
 class IndexedIriWriter(index: Map[IRI, Int]) extends Serializer[IRI]:
 	override def read(kryo: Kryo, input: Input, tpe: Class[? <: IRI]): IRI = ???
 	override def write(kryo: Kryo, output: Output, iri: IRI): Unit =
-		val idx = if iri == null then -1 else index.getOrElse(iri, -1)
+		val idx = if iri == null then -1 else index(iri)
 		output.writeInt(idx)
 
 class IndexedIriReader(index: IndexedSeq[IRI]) extends Serializer[IRI]:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
@@ -246,7 +246,7 @@ object IndexDataSerializer extends Serializer[IndexData]:
 		.distinct
 		.toArray
 
-	private def buildIriIndex(objs: ArrayBuffer[ObjEntry], specs: Iterable[IRI]): Array[IRI] = {
+	private def buildIriIndex(objs: ArrayBuffer[ObjEntry], specs: Set[IRI]): Array[IRI] = {
 		val objectIRIs =
 			objs
 				.iterator

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/IndexHandler.scala
@@ -324,7 +324,7 @@ object IriSerializer extends Serializer[IRI]:
 class IndexedIriWriter(index: Map[IRI, Int]) extends Serializer[IRI]:
 	override def read(kryo: Kryo, input: Input, tpe: Class[? <: IRI]): IRI = ???
 	override def write(kryo: Kryo, output: Output, iri: IRI): Unit =
-		val idx = if iri == null then -1 else index(iri)
+		val idx = if iri == null then -1 else index.getOrElse(iri, -1)
 		output.writeInt(idx)
 
 class IndexedIriReader(index: IndexedSeq[IRI]) extends Serializer[IRI]:

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -138,8 +138,6 @@ final class IndexData(nObjects: Int)(
 								oe.spec = null
 							}
 						}
-						// TODO Make sure the next line is not needed, and remove
-						//updateSpecOwnKeywords(spec, true, Set.empty)
 					}
 				}
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -140,12 +140,6 @@ final class IndexData(nObjects: Int)(
 								oe.spec = null
 							}
 						}
-
-						// Covers the case when keywords have been added to a spec,
-						// before any data object is associated with that spec.
-						// TODO: This makes indexing quite a lot slower, and could be removed
-						// if specs can be reliably identified without relying on hasObjectSpec.
-						updateSpecOwnKeywords(spec, true, Set.empty)
 					}
 				}
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -94,7 +94,7 @@ final class IndexData(nObjects: Int)(
 		prop match
 			case Keyword =>
 				val keywordsToObjs = categMap(Keyword)
-				(keywordsToSpecs.keys ++ keywordsToObjs.keys).toSet.map(_.asInstanceOf[prop.ValueType])
+				(keywordsToSpecs.keySet ++ keywordsToObjs.keySet).map(_.asInstanceOf[prop.ValueType])
 			case _ =>
 				categMap(prop).keys
 	}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -2,6 +2,7 @@ package se.lu.nateko.cp.meta.services.sparql.magic.index
 
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value}
+import org.eclipse.rdf4j.model.vocabulary.RDF
 import org.roaringbitmap.buffer.MutableRoaringBitmap
 import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.core.algo.DatetimeHierarchicalBitmap.DateTimeGeo
@@ -345,7 +346,8 @@ final class IndexData(nObjects: Int)(
 							}
 						}
 						case None => if (changedKeywords.nonEmpty) {
-								val isSpec = StatementSource.hasStatement(null, vocab.hasObjectSpec, subj)
+								val isSpec = StatementSource.hasStatement(subj, RDF.TYPE, vocab.dataObjectSpecClass) ||
+									StatementSource.hasStatement(subj, RDF.TYPE, vocab.simpleObjectSpecClass)
 
 								if (isSpec)
 									updateSpecOwnKeywords(subj, isAssertion, changedKeywords)

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -96,14 +96,14 @@ final class IndexData(nObjects: Int)(
 		categoryBitmap(prop, categoryKeys(prop).filter(predicate))
 	}
 
-	def categoryKeys(prop: CategProp): Iterable[prop.ValueType] = {
+	def categoryKeys(prop: CategProp): Set[prop.ValueType] = {
 		prop match
 			case Keyword =>
 				val keywordsToObjs = categMap(Keyword)
 				Set.concat(keywordsToSpecs.keySet, keywordsToObjs.keySet)
 					.map(_.asInstanceOf[prop.ValueType])
 			case _ =>
-				categMap(prop).keys
+				categMap(prop).keysIterator.toSet
 	}
 
 	private def categMap(prop: CategProp): AnyRefMap[prop.ValueType, MutableRoaringBitmap] = {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -138,6 +138,8 @@ final class IndexData(nObjects: Int)(
 								oe.spec = null
 							}
 						}
+						// TODO Make sure the next line is not needed, and remove
+						//updateSpecOwnKeywords(spec, true, Set.empty)
 					}
 				}
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -130,14 +130,20 @@ final class IndexData(nObjects: Int)(
 				obj match {
 					case spec: IRI => {
 						getDataObject(subj).foreach { oe =>
-							updateCategSet(categMap(Spec), spec, oe.idx, isAssertion)
+							val specBitmap = categMap(Spec).getOrElseUpdate(spec, emptyBitmap)
+
 							if (isAssertion) {
+								specBitmap.add(oe.idx)
 								if (oe.spec != null) removeStat(oe, initOk)
 								oe.spec = spec
 								addStat(oe, initOk)
-							} else if (spec === oe.spec) {
-								removeStat(oe, initOk)
-								oe.spec = null
+							} else {
+								specBitmap.remove(oe.idx)
+
+								if (spec === oe.spec) {
+									removeStat(oe, initOk)
+									oe.spec = null
+								}
 							}
 						}
 					}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -138,8 +138,8 @@ final class IndexData(nObjects: Int)(
 								oe.spec = null
 							}
 						}
-						// TODO Make sure the next line is not needed, and remove
-						//updateSpecOwnKeywords(spec, true, Set.empty)
+
+						updateSpecOwnKeywords(spec, true, Set.empty)
 					}
 				}
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/SparqlRouteTests.scala
@@ -204,16 +204,16 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 					res
 				}
 
-				// Launch several requests than the value of maxParallelQueries,
+				// Launch several more requests than the value of maxParallelQueries,
 				// some of which should be rejected.
-				val requests = Seq.range(0, 6).map(launchRequest)
+				val requests = Seq.range(0, 10).map(launchRequest)
 
 				Future.sequence(requests).map(results =>
 					val statuses = results.map(_.status)
 					info(s"statuses: ${statuses.toString()}")
 					val accepted = statuses.filter(_ == StatusCodes.OK)
 					val rejected = statuses.filter(_ == StatusCodes.BadRequest)
-					assert(accepted.length >= 1)
+					assert(accepted.length >= sparqlConfig.maxParallelQueries)
 					assert(rejected.length >= 1)
 				)
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -12,6 +12,7 @@ import se.lu.nateko.cp.meta.utils.rdf4j.Rdf4jStatement
 import org.eclipse.rdf4j.model.Resource
 import org.roaringbitmap.buffer.MutableRoaringBitmap
 import scala.util.Random
+import org.eclipse.rdf4j.model.vocabulary.RDF
 
 private val factory = SimpleValueFactory.getInstance()
 
@@ -78,6 +79,8 @@ class IndexDataTest extends AnyFunSpec {
 		// Shuffle the rest of the statements.
 		val statements =
 			Seq(
+				Rdf4jStatement(spec, RDF.TYPE, vocab.dataObjectSpecClass),
+				Rdf4jStatement(otherSpec, RDF.TYPE, vocab.dataObjectSpecClass),
 				Rdf4jStatement(dataObject, hasKeywords, factory.createLiteral("object keyword")),
 				Rdf4jStatement(otherDataObject, hasKeywords, factory.createLiteral("other-object keyword"))
 			)
@@ -162,6 +165,7 @@ class IndexDataTest extends AnyFunSpec {
 
 		// Set up object->spec->project chain
 		val objSpecProj = Random.shuffle(Seq(
+			(true, Rdf4jStatement(spec, RDF.TYPE, vocab.dataObjectSpecClass)),
 			(true, Rdf4jStatement(dataObject, hasKeywords, factory.createLiteral("object keyword"))),
 			(true, Rdf4jStatement(dataObject, hasObjectSpec, spec)),
 			(true, Rdf4jStatement(spec, hasKeywords, factory.createLiteral("spec keyword"))),

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -32,7 +32,6 @@ class IndexDataTest extends AnyFunSpec {
 	import vocab.{hasKeywords, hasName, hasObjectSpec, hasAssociatedProject}
 
 	val seed = Math.abs(Random.nextInt())
-	// val seed = 1594785910
 	Random.setSeed(seed)
 	info(s"Random seed: $seed")
 
@@ -185,16 +184,19 @@ class IndexDataTest extends AnyFunSpec {
 		testCase("object keyword is added") {
 			val addObjectKeyword = (true, Rdf4jStatement(dataObject, hasKeywords, factory.createLiteral("object edited")))
 
-			val statements = objSpecProj :+ addObjectKeyword
-			assertIndex(
-				statements,
-				Map(
-					"object keyword" -> objectBitmap,
-					"object edited" -> objectBitmap,
-					"spec keyword" -> objectBitmap,
-					"project keyword" -> objectBitmap
+			// Try all permutations of the basic case here, so we don't have to do it in all other tests.
+			objSpecProj.permutations.foreach(baseStatements => {
+				val statements = baseStatements :+ addObjectKeyword
+				assertIndex(
+					statements,
+					Map(
+						"object keyword" -> objectBitmap,
+						"object edited" -> objectBitmap,
+						"spec keyword" -> objectBitmap,
+						"project keyword" -> objectBitmap
+					)
 				)
-			)
+			})
 		}
 
 		testCase("object keyword is removed") {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -277,12 +277,7 @@ class IndexDataTest extends AnyFunSpec {
 
 		testCase("associated spec is removed") {
 			val removeSpec = (false, Rdf4jStatement(dataObject, hasObjectSpec, spec))
-			assertIndex(
-				objSpecProj :+ removeSpec,
-				Map(
-					"object keyword" -> objectBitmap
-				)
-			)
+			assertIndex(objSpecProj :+ removeSpec, Map("object keyword" -> objectBitmap))
 		}
 
 		testCase("spec with keywords overlapping data object is removed") {
@@ -334,12 +329,7 @@ class IndexDataTest extends AnyFunSpec {
 				)
 			)
 
-			assertIndex(
-				statements :+ removeSpec,
-				Map(
-					"object keyword" -> objectBitmap
-				)
-			)
+			assertIndex(statements :+ removeSpec, Map("object keyword" -> objectBitmap))
 		}
 
 		testCase("overlapping keywords in spec is removed") {
@@ -350,12 +340,7 @@ class IndexDataTest extends AnyFunSpec {
 			)) :+
 				(false, Rdf4jStatement(spec, hasKeywords, factory.createLiteral("overlap")))
 
-			assertIndex(
-				statements,
-				Map(
-					"overlap" -> objectBitmap
-				)
-			)
+			assertIndex(statements, Map("overlap" -> objectBitmap))
 		}
 
 		testCase("overlapping keywords in project is removed") {

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -381,6 +381,21 @@ class IndexDataTest extends AnyFunSpec {
 
 			assertIndex(statements, Map("spec keyword" -> objectBitmap))
 		}
+
+		testCase("keywords are added to spec after last object was removed") {
+			val statements = Seq(
+				// Add spec and object
+				(true, Rdf4jStatement(spec, RDF.TYPE, vocab.dataObjectSpecClass)),
+				(true, Rdf4jStatement(dataObject, hasObjectSpec, spec)),
+				// Remove the object, and add keyword to spec
+				(false, Rdf4jStatement(dataObject, hasObjectSpec, spec)),
+				(true, Rdf4jStatement(spec, hasKeywords, factory.createLiteral("spec keyword"))),
+				// Add object again. It should receive the spec keyword
+				(true, Rdf4jStatement(dataObject, hasObjectSpec, spec))
+			)
+
+			assertIndex(statements, Map("spec keyword" -> objectBitmap))
+		}
 	}
 }
 

--- a/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/services/sparql/index/IndexDataTest.scala
@@ -327,6 +327,16 @@ class IndexDataTest extends AnyFunSpec {
 
 			assert(runStatements(statements) == Map("overlap" -> objectBitmap))
 		}
+
+		testCase("spec with keywords is added before object association") {
+			val statements = Seq(
+				(true, Rdf4jStatement(spec, hasAssociatedProject, project)),
+				(true, Rdf4jStatement(spec, hasKeywords, factory.createLiteral("spec keyword"))),
+				(true, Rdf4jStatement(dataObject, hasObjectSpec, spec))
+			)
+
+			assert(runStatements(statements) == Map("spec keyword" -> objectBitmap))
+		}
 	}
 }
 


### PR DESCRIPTION
Followup of https://github.com/ICOS-Carbon-Portal/meta/pull/306

- Changes strategy for identifying object specs, by relying on `RDF.TYPE` triples and remembering any seen specs by creating entries in `categMaps(Spec)`
- Improves tests, making sure we cover all permutations of statement processing order and that specs are not forgotten after being seen.