### PR TITLE
Magic query: Unique keywords based on object filtering

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpEvaluationStrategyFactory.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpEvaluationStrategyFactory.scala
@@ -42,6 +42,16 @@ class CpEvaluationStrategyFactory(
 					val statsBindings = bindingsForStatsFetch(statsFetch).toIndexedSeq
 					qEvalStep(_ => statsBindings.iterator)
 
+				case UniqueKeywordsNode(bindingName, doFetch) => {
+					qEvalStep(existingBindings => {
+						val fetchRequest = getFilterEnrichedDobjFetch(doFetch, existingBindings)
+						val keywords = index.getUniqueKeywords(fetchRequest)
+						val bs = new QueryBindingSet(existingBindings)
+						bs.setBinding(bindingName, index.factory.createLiteral(keywords.mkString(",")))
+						Seq(bs).iterator
+					})
+				}
+
 				case _ => super.precompile(expr, context)
 
 			override def optimize(expr: TupleExpr, stats: EvaluationStatistics, bindings: BindingSet): TupleExpr = {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/CpIndex.scala
@@ -123,6 +123,11 @@ class CpIndex(sail: Sail, geo: Future[GeoIndex], data: IndexData) extends ReadWr
 		}
 	}
 
+	def getUniqueKeywords(req: DataObjectFetch): Iterable[String] = readLocked {
+		val objectIds = filtering(req.filter).fold(initOk)(BufferFastAggregation.and(_, initOk))
+		data.getObjectKeywords(objectIds)
+	}
+
 	def lookupObject(hash: Sha256Sum): Option[ObjInfo] = idLookup.get(hash).map(objs.apply)
 
 	def getObjEntry: Sha256Sum => ObjInfo =

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPattern.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPattern.scala
@@ -19,6 +19,12 @@ object DofPattern{
 	val Empty = PlainDofPattern(None, Map.empty, Map.empty, Nil)
 }
 
+final case class UniqueKeywordsPattern(bindingName: String, expression: Extension, pattern: DofPattern) extends DofPattern {
+	override protected def joinInner(other: DofPattern): DofPattern = {
+		throw new Exception("Unique keywords query cannot be joined")
+	}
+}
+
 sealed trait QVar{
 	def name: String
 }

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
@@ -82,7 +82,7 @@ class DofPatternFusion(meta: CpmetaVocab){
 		case plain: PlainDofPattern => findPlainFusion(plain).toSeq
 
 		case UniqueKeywordsPattern(bindingName, expression, innerPattern) => {
-			// Clauses which are not handled by DobjListFusion are skipped here.
+			// NOTE: Clauses which are not handled by DobjListFusion are skipped here.
 			// Example: FILTER(STRSTARTS(str(?spec), "https://meta.fieldsites.se/")) will be ignored.
 			val fusions : Seq[DobjListFusion] = findFusions(innerPattern).flatMap(fusion =>
 					fusion match {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternFusion.scala
@@ -29,6 +29,8 @@ case class DobjListFusion(
 	def nonMagicNodeIds = nonMagicQMNodes.map(System.identityHashCode).toSet
 }
 
+final case class UniqueKeywordsFusion(bindingName: String, expression: TupleExpr, fusion: DobjListFusion) extends FusionPattern
+
 class DofPatternFusion(meta: CpmetaVocab){
 
 	def findFusions(patt: DofPattern): Seq[FusionPattern] = patt match{
@@ -79,6 +81,23 @@ class DofPatternFusion(meta: CpmetaVocab){
 
 		case plain: PlainDofPattern => findPlainFusion(plain).toSeq
 
+		case UniqueKeywordsPattern(bindingName, expression, innerPattern) => {
+			// Clauses which are not handled by DobjListFusion are skipped here.
+			// Example: FILTER(STRSTARTS(str(?spec), "https://meta.fieldsites.se/")) will be ignored.
+			val fusions : Seq[DobjListFusion] = findFusions(innerPattern).flatMap(fusion =>
+					fusion match {
+						case f: DobjListFusion => Some(f)
+						case _ => None
+					}
+				)
+
+			fusions match {
+				case Seq(fusion) =>
+					Seq(UniqueKeywordsFusion(bindingName, expression, fusion))
+				case _ =>
+					throw new Exception("Expected a single DobjListFusion in unique keywords query")
+			}
+		}
 	}
 
 	def addOrderByAndOffset(pdp: ProjectionDofPattern, inner: DobjListFusion): DobjListFusion = {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternSearch.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/DofPatternSearch.scala
@@ -116,6 +116,9 @@ class DofPatternSearch(meta: CpmetaVocab){
 				case _ => DofPattern.Empty
 			}
 
+		case DistinctKeywordsExtension(bindingName, ext) =>
+			UniqueKeywordsPattern(bindingName, ext, find0(ext.getArg()))
+
 		case ext: Extension =>
 			val groupByOpt = for(
 				(countVar, dobjCandVar) <- singleCountExtension(ext);
@@ -150,7 +153,30 @@ class DofPatternSearch(meta: CpmetaVocab){
 		case _ => DofPattern.Empty
 
 	}
+}
 
+final case class DistinctKeywordsExtension(bindingName: String, ext: Extension)
+object DistinctKeywordsExtension {
+	def unapply(expr: TupleExpr): Option[DistinctKeywordsExtension] = {
+		expr match {
+			case ext: Extension => findDistinctKeywordsBinding(ext).map(bindingName =>
+					DistinctKeywordsExtension(bindingName, ext)
+				)
+			case _ => None
+		}
+	}
+
+	private def findDistinctKeywordsBinding(ext: Extension): Option[String] = {
+		ext.getElements().asScala.headOption.flatMap(elem =>
+			elem.getExpr() match {
+				case f: FunctionCall if f.getURI() == "http://meta.icos-cp.eu/ontologies/cpmeta/distinct_keywords" => {
+					Some(elem.getName())
+				}
+				case _ =>
+					None
+			}
+		)
+	}
 }
 
 object DofPatternSearch{

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/UniqueKeywordsNode.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/fusion/UniqueKeywordsNode.scala
@@ -1,0 +1,18 @@
+package se.lu.nateko.cp.meta.services.sparql.magic.fusion
+import org.eclipse.rdf4j.query.algebra.{AbstractQueryModelNode, TupleExpr, QueryModelVisitor, QueryModelNode}
+
+// This is a special node which is only used to carry a wrapped DataObjectFetchNode.
+// Execution is entirely managed by us in CpEvaluationStrategyFactory, hence we can ignore all visitors.
+final case class UniqueKeywordsNode(bindingName: String, inner: DataObjectFetchNode) extends AbstractQueryModelNode with TupleExpr {
+	override def getSignature(): String = s"UniqueKeywordsNode($inner)"
+	override def visit[X <: Exception](visitor: QueryModelVisitor[X]): Unit = {}
+
+	override def getBindingNames() = unexpected("getBindingNames")
+	override def getAssuredBindingNames() = unexpected("getAssuredBindingNames")
+	override def clone() = unexpected("clone")
+	override def visitChildren[X <: Exception](visitor: QueryModelVisitor[X]): Unit = unexpected("visitChildren")
+	override def replaceChildNode(current: QueryModelNode, replacement: QueryModelNode): Unit = unexpected("replaceChildNode")
+
+	private def unexpected(methodName: String) =
+		throw new Exception(s"Unexpected call to UniqueKeywordsNode.${methodName}")
+}

--- a/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/sparql/magic/index/IndexData.scala
@@ -66,6 +66,13 @@ final class IndexData(nObjects: Int)(
 		boolMap.getOrElseUpdate(prop, emptyBitmap)
 	}
 
+	def getObjectKeywords(objectIds: ImmutableRoaringBitmap): Iterable[String] = {
+		categoryKeys(Keyword).collect {
+			case keyword if !BufferFastAggregation.and(objectIds, keywordBitmap(Seq(keyword))).isEmpty() =>
+				keyword
+		}
+	}
+
 	def bitmap(prop: ContProp): HierarchicalBitmap[prop.ValueType] =
 		contMap.getOrElseUpdate(
 			prop,


### PR DESCRIPTION
This PR is based on https://github.com/ICOS-Carbon-Portal/meta/pull/308, which should be merged first.

This implements a new magic query returning a list of unique keywords, given a data object filter. The only current use-case is for filtering the keywords list on https://data.icos-cp.eu/portal/

The shape of the query is: 
```
prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
select (cpmeta:distinct_keywords() AS ?keywords) where {
  // Data object filter
}
```

- `cpmeta:distinct_keywords()` is the special function triggering the query, and no other bindings will be set when it is used.
- The body of the query must match the shape of our magic data object query, since this implementation builds directly upon that, which also matches the use-case in the portal (filtering keywords based on filtered data objects).
- **Note:** This implementation ignores any filtering clauses that are not handled by the magic data object query. For example things like `FILTER(STRSTARTS(str(?spec), "http://meta.icos-cp.eu/"))`. This means that some keywords which do not have any results may still slip through, in some circumstances. In practice, those filtering clauses are only  used when no filters at all are applied in the portal UI, making it a fairly unimportant case. Handling such filter clauses makes the implementation a lot harder, and this level of filtering is still a huge improvement on what we had before, hence I think we can leave that as a possible future(or never) improvement.

