### PR TITLE
Create logback configuration for development

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val meta = (project in file("."))
 			"com.typesafe.akka"     %% "akka-http-caching"                  % akkaHttpVersion cross CrossVersion.for3Use2_13,
 			"com.typesafe.akka"     %% "akka-stream"                        % akkaVersion cross CrossVersion.for3Use2_13,
 			"com.typesafe.akka"     %% "akka-slf4j"                         % akkaVersion cross CrossVersion.for3Use2_13,
-			"ch.qos.logback"         % "logback-classic"                    % "1.1.3",
+			"ch.qos.logback"         % "logback-classic"                    % "1.4.14",
 			"org.eclipse.rdf4j"      % "rdf4j-repository-sail"              % rdf4jVersion,
 			"org.eclipse.rdf4j"      % "rdf4j-sail-memory"                  % rdf4jVersion,
 			"org.eclipse.rdf4j"      % "rdf4j-sail-nativerdf"               % rdf4jVersion,
@@ -196,6 +196,13 @@ lazy val meta = (project in file("."))
 		watchSources ++= (uploadgui / Compile / watchSources).value,
 
 		reStart / aggregate := false,
+
+		reStart / javaOptions ++= Seq(
+			"-Dlogback.configurationFile=logback-dev.xml"
+		),
+
+		// Hide the process name prefix in reStart output
+		reStart / reLogTag := "",
 
 		// Test / console / initialCommands := {
 		// 	"""import se.lu.nateko.cp.meta.upload.UploadWorkbench.{given, *}"""

--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>[%highlight(%level)] %cyan(%logger{0}) %msg %n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="info">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+	<logger name="org.semanticweb.owlapi.rdf.rdfxml.parser.OWLRDFConsumer" level="WARN" />
+
+</configuration>


### PR DESCRIPTION
Use a separate Logback configuration for development that uses colors and a simplified output. 
- Remove the project prefix name ("meta" in the example bellow)
- Remove the timestamps
- Remove the source actor
- Add color to the log level and logger

Before
<img width="834" height="168" alt="Screenshot 2025-09-09 at 08 23 26" src="https://github.com/user-attachments/assets/f8341e68-7e10-4cd8-beae-7d463ff01df5" />

After
<img width="779" height="107" alt="Screenshot 2025-09-09 at 08 17 58" src="https://github.com/user-attachments/assets/cf90ec53-4721-4a89-966f-68a5c0cd6ddd" />

This would make it easier to parse the output, and should contain the information needed most of the time.
We could also move this somewhere else to make it easier to share between projects, maybe in the infrastructure repo?