### PR TITLE
Convert CityNetwork type to enum

### DIFF
--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/JsonSupport.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/JsonSupport.scala
@@ -245,10 +245,10 @@ object JsonSupport extends CommonJsonSupport:
 	given RootJsonFormat[OtcStationSpecifics] = jsonFormat6(OtcStationSpecifics.apply)
 	given RootJsonFormat[SitesStationSpecifics] = jsonFormat8(SitesStationSpecifics.apply)
 	given JsonFormat[CityNetwork] with
-		def write(cn: CityNetwork): JsValue = JsString(cn)
+		def write(cn: CityNetwork): JsValue = JsString(cn.toString)
 		def read(js: JsValue): CityNetwork = js match
 			case JsString(s) => cityNetworkFromStr(s)
-			case _ => "Unspecified"
+			case _ => CityNetwork.Unspecified
 
 	given RootJsonFormat[IcosCitiesStationSpecifics] = jsonFormat2(IcosCitiesStationSpecifics.apply)
 

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/Station.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/Station.scala
@@ -122,11 +122,12 @@ case class EtcStationSpecifics(
 }
 
 //TODO Consider removing "Unspecified" option later
-type CityNetwork = "Munich" | "Paris" | "Zurich" | "Barcelona" | "Unspecified"
+enum CityNetwork:
+    case `Munich`, `Paris`, `Zurich`, `Barcelona`, Unspecified
 
 def cityNetworkFromStr(s: String): CityNetwork = s match
-	case city: ("Munich" | "Paris" | "Zurich" | "Barcelona") => city
-	case _ => "Unspecified"
+	case city: ("Munich" | "Paris" | "Zurich" | "Barcelona") => CityNetwork.valueOf(city)
+	case _ => CityNetwork.Unspecified
 
 
 

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/RdfMaker.scala
@@ -220,7 +220,7 @@ class RdfMaker(vocab: CpVocab, val meta: CpmetaVocab)(using Envri) {
 		case icos: IcosStationSpecifics =>
 			plainIcosStationSpecTriples(iri, icos)
 		case cities: IcosCitiesStationSpecifics =>
-			(iri, meta.belongsToNetwork, vocab.lit(cities.network)) +:
+			(iri, meta.belongsToNetwork, vocab.lit(cities.network.toString)) +:
 			cities.timeZoneOffset.toSeq.map: tzoff =>
 				(iri, meta.hasTimeZoneOffset, vocab.lit(tzoff))
 		case other: (SitesStationSpecifics | NoStationSpecifics.type) => Seq.empty

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesMetaFlow.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesMetaFlow.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import eu.icoscp.envri.Envri
-import se.lu.nateko.cp.meta.core.data.{AtcStationSpecifics, CountryCode, EnvriConfigs, IcosCitiesStationSpecifics}
+import se.lu.nateko.cp.meta.core.data.{AtcStationSpecifics, CityNetwork, CountryCode, EnvriConfigs, IcosCitiesStationSpecifics}
 import se.lu.nateko.cp.meta.metaflow.*
 import se.lu.nateko.cp.meta.metaflow.icos.{ATC, AtcConf, AtcMetaSource}
 import se.lu.nateko.cp.meta.services.MetadataException
@@ -40,7 +40,7 @@ object CitiesMetaFlow:
 	def injectNetworkInfo(state: TcState[ATC.type]): TcState[ATC.type] =
 		val stations = state.stations.map: s =>
 			val citySpec = s.core.specificInfo match
-				case atc: AtcStationSpecifics => IcosCitiesStationSpecifics(atc.timeZoneOffset, "Paris")
+				case atc: AtcStationSpecifics => IcosCitiesStationSpecifics(atc.timeZoneOffset, CityNetwork.Paris)
 				case _ => throw MetadataException("Unexpected station-specific info, must be AtcStationSpecifics")
 			s.copy(core = s.core.copy(specificInfo = citySpec))
 		TcState(stations, state.roles, state.instruments)

--- a/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesTcConf.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/metaflow/cities/CitiesTcConf.scala
@@ -8,17 +8,17 @@ import se.lu.nateko.cp.meta.services.CpmetaVocab
 
 sealed trait CitiesTC(val network: CityNetwork) extends TC
 
-case object MunichMidLow extends CitiesTC("Munich")
-case object ParisMidLow extends CitiesTC("Paris")
-case object ZurichMidLow extends CitiesTC("Zurich")
+case object MunichMidLow extends CitiesTC(CityNetwork.Munich)
+case object ParisMidLow extends CitiesTC(CityNetwork.Paris)
+case object ZurichMidLow extends CitiesTC(CityNetwork.Zurich)
 
 sealed class CityTcConf[CTC <: CitiesTC](
 	val tc: CTC,
 	classGetter: CpmetaVocab => IRI,
 	predGetter: CpmetaVocab => IRI
 ) extends TcConf[CTC]:
-	val stationPrefix = tc.network
-	val tcPrefix = tc.network
+	val stationPrefix = tc.network.toString
+	val tcPrefix = tc.network.toString
 	def stationClass(meta: CpmetaVocab): IRI = classGetter(meta)
 	def tcIdPredicate(meta: CpmetaVocab): IRI = predGetter(meta)
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
@@ -171,7 +171,7 @@ trait DobjMetaReader(val vocab: CpVocab) extends CpmetaReader:
 				networkStr <- getOptionalString(stat, metaVocab.belongsToNetwork)
 			yield IcosCitiesStationSpecifics(
 				timeZoneOffset,
-				networkStr.fold("Unspecified")(cityNetworkFromStr)
+				networkStr.fold(CityNetwork.Unspecified)(cityNetworkFromStr)
 			)
 		else Validated.ok(NoStationSpecifics)
 	end getStationSpecifics


### PR DESCRIPTION
The TypeScript and Python types generation started to fail because we do not handle the `type` keyword properly. We should fix the code generation, but it also felt like an enum was better suited in this case. This change fixes the type generation, and hopefully won't cause any regression. I will already merge and deploy this issue prevents `data` from being deployed. Please still take a look at this and provide some feedback when you get the chance.