### PR TITLE
Change from imported givens to explicit calls in UriSerializer

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala
@@ -35,12 +35,7 @@ import se.lu.nateko.cp.meta.services.CpVocab
 import se.lu.nateko.cp.meta.services.MetadataException
 import se.lu.nateko.cp.meta.services.citation.CitationMaker
 import se.lu.nateko.cp.meta.services.citation.PlainDoiCiter
-import se.lu.nateko.cp.meta.services.upload.{
-	PageContentMarshalling,
-	StaticObjectMarshaller,
-	StaticCollectionMarshaller,
-	StaticObjectReader
-}
+import se.lu.nateko.cp.meta.services.upload.{PageContentMarshalling, StaticObjectReader}
 import se.lu.nateko.cp.meta.utils.Validated
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 import se.lu.nateko.cp.meta.views.ResourceViewInfo
@@ -253,7 +248,7 @@ class Rdf4jUriSerializer(
 				pageContentMarshalling.staticObjectMarshaller(() => fetchStaticObj(hash))
 
 			case Hash.Collection(hash) =>
-				pageContentMarshalling.statCollMarshaller(() => fetchStaticColl(hash))
+				pageContentMarshalling.staticCollectionMarshaller(() => fetchStaticColl(hash))
 
 			case UriPath("resources", "stations", stId) => resourceMarshallings(
 				stId, "station", fetchStation,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
@@ -21,12 +21,14 @@ import views.html.{CollectionLandingPage, LandingPage, MessagePage}
 import java.util.concurrent.ExecutionException
 import scala.concurrent.{ExecutionContext, Future}
 
+type StaticObjectMarshaller = ToResponseMarshaller[() => Validated[StaticObject]]
+type StaticCollectionMarshaller = ToResponseMarshaller[() => Validated[StaticCollection]]
 
 class PageContentMarshalling(handleProxies: HandleProxiesConfig, statisticsClient: StatisticsClient):
 
 	import PageContentMarshalling.*
 
-	given staticObjectMarshaller (using Envri, EnvriConfig, CpVocab) : ToResponseMarshaller[() => Validated[StaticObject]] =
+	given (using Envri, EnvriConfig, CpVocab): StaticObjectMarshaller =
 		import statisticsClient.executionContext
 		val template: PageTemplate[StaticObject] = (obj, errors) =>
 			for(
@@ -39,7 +41,7 @@ class PageContentMarshalling(handleProxies: HandleProxiesConfig, statisticsClien
 		makeMarshaller(template, messagePage("Data object not found", _))
 
 
-	given statCollMarshaller(using Envri, EnvriConfig): ToResponseMarshaller[() => Validated[StaticCollection]] =
+	given (using Envri, EnvriConfig): StaticCollectionMarshaller =
 		import statisticsClient.executionContext
 		val template: PageTemplate[StaticCollection] = (coll, errors) =>
 			for(dlCount <- statisticsClient.getCollDownloadCount(coll.res))

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
@@ -21,9 +21,6 @@ import views.html.{CollectionLandingPage, LandingPage, MessagePage}
 import java.util.concurrent.ExecutionException
 import scala.concurrent.{ExecutionContext, Future}
 
-type StaticObjectMarshaller = ToResponseMarshaller[() => Validated[StaticObject]]
-type StaticCollectionMarshaller = ToResponseMarshaller[() => Validated[StaticCollection]]
-
 class PageContentMarshalling(handleProxies: HandleProxiesConfig, statisticsClient: StatisticsClient):
 
 	import PageContentMarshalling.*
@@ -41,7 +38,7 @@ class PageContentMarshalling(handleProxies: HandleProxiesConfig, statisticsClien
 		makeMarshaller(template, messagePage("Data object not found", _))
 
 
-	def statCollMarshaller(using Envri, EnvriConfig): ToResponseMarshaller[() => Validated[StaticCollection]] =
+	def staticCollectionMarshaller(using Envri, EnvriConfig): ToResponseMarshaller[() => Validated[StaticCollection]] =
 		import statisticsClient.executionContext
 		val template: PageTemplate[StaticCollection] = (coll, errors) =>
 			for(dlCount <- statisticsClient.getCollDownloadCount(coll.res))

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala
@@ -28,7 +28,7 @@ class PageContentMarshalling(handleProxies: HandleProxiesConfig, statisticsClien
 
 	import PageContentMarshalling.*
 
-	given (using Envri, EnvriConfig, CpVocab): StaticObjectMarshaller =
+	def staticObjectMarshaller (using Envri, EnvriConfig, CpVocab) : ToResponseMarshaller[() => Validated[StaticObject]] =
 		import statisticsClient.executionContext
 		val template: PageTemplate[StaticObject] = (obj, errors) =>
 			for(
@@ -41,7 +41,7 @@ class PageContentMarshalling(handleProxies: HandleProxiesConfig, statisticsClien
 		makeMarshaller(template, messagePage("Data object not found", _))
 
 
-	given (using Envri, EnvriConfig): StaticCollectionMarshaller =
+	def statCollMarshaller(using Envri, EnvriConfig): ToResponseMarshaller[() => Validated[StaticCollection]] =
 		import statisticsClient.executionContext
 		val template: PageTemplate[StaticCollection] = (coll, errors) =>
 			for(dlCount <- statisticsClient.getCollDownloadCount(coll.res))


### PR DESCRIPTION
After spending some time in this code together with @jonathanlindahl this morning, I think the current implementation is a bit too confusing, and this is an attempt at a slight improvement while staying functionally the same (I believe).

### What I find confusing:
This function maps routes to different marshallings (views, basically). We can see that it takes 3 implicit (given) arguments `(Envri, EnvriConfig and ExecutionContext)`: https://github.com/ICOS-Carbon-Portal/meta/blob/d9db240b074bd9a51dffff4f88aa5b2ece7ff4c0/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala#L225
For objects and collections, it then calls https://github.com/ICOS-Carbon-Portal/meta/blob/d9db240b074bd9a51dffff4f88aa5b2ece7ff4c0/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala#L298-L300 from
https://github.com/ICOS-Carbon-Portal/meta/blob/d9db240b074bd9a51dffff4f88aa5b2ece7ff4c0/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala#L254-L259
In `delegatedRepr`, we require a given with the type `ToResponseMarshaller[() => Validated[T]]`, and in this case `T` is `StaticObject` or `StaticCollection`.

**The big question:**
Looking at `getMarshallings`, we have the 3 givens stated above, and none of them are what is expected in `delegateRepr`. Yet, we apparently have access to these givens when calling it. This means, they must be available in the outer scope of the class, or through some import mechanism, but there is no explicit such place in the file.

**The answer (partly)**
In Scala, `import` does much more than in Java, and can be used to import members from values inside scopes, rather than just types and functions from modules. Classes can have `given`'s as members and they can be public, so they can be used from outside, and hence we can also import given values. That is what happens here: https://github.com/ICOS-Carbon-Portal/meta/blob/e90d25ffd35707044588ca8e55b2ffbf8e2d10db/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala#L110-L115

**The STILL VERY CONFUSING part**
So, we now have the values `staticObjectMarshaller` and `statCollMarshaller` in the scope of the class, and the definition of the first one is https://github.com/ICOS-Carbon-Portal/meta/blob/e90d25ffd35707044588ca8e55b2ffbf8e2d10db/src/main/scala/se/lu/nateko/cp/meta/services/upload/PageContentMarshalling.scala#L29
From now on I'll focus only on staticObjectMarshaller, since the same thing applies to statCollMarshaller.
The final type of these `given`'s match what we want in `delegatedRepr`, but things don't fully make sense yet. To instantiate `staticObjectMarshaller`, we need
```scala
(using Envri, EnvriConfig, CpVocab)
```
At the point where we do
```scala
import pcm.{staticObjectMarshaller, statCollMarshaller}
```
we only have access to
```scala
given CpVocab = vocab
```
on the line above.

This means that what we have in scope (the value `staticObjectMarshaller`) is a `given`, which can be resolved if the `given`s which it depends on are also in scope, but we do not have instances of `Envri` or `EnvriConfig` in scope yet. Thise givens are actually set just before calling `getMarshallings`, here:
https://github.com/ICOS-Carbon-Portal/meta/blob/e90d25ffd35707044588ca8e55b2ffbf8e2d10db/src/main/scala/se/lu/nateko/cp/meta/services/linkeddata/UriSerializer.scala#L120-L125

**Recap**
* Going back to `getMarshallings`, where we call `delegatedRepr`, we know that we have a `given` instance of `ToResponseMarshaller[() => Validated[StaticObject]]` available.
* We have `staticObjectMarshaller` in scope of the class, which is a `given` with the expected final type, but which expects 3 `givens` in order to resolve. One (`CpVocab`) is available, and two are not.
* Before calling `getMarshallings`, the other two (`Envri` and `EnvriConfig`) are set.

**The final answer**
Putting all of this together, what I believe happens is this:
* `delegatedRepr` tries to look up a `given` with the type `ToResponseMarshaller[() => Validated[StaticObject]]`
* We have such a given in scope, which is the member `staticObjectMarshaller` which is imported into scope from the value `pcm`, which is a `PageContentMarshaller`.
* When it tries to use `staticObjectMarshaller`, that in turn requires 3 more givens, and they are in scope (when called from `getMarshallings`), so the `staticObjectMarshaller` can be constructed here.

**Side note**
If you grep the code for `Validated[StaticObject]`, it may lead you to `staticObjectMarshaller` in `PageContentMarshaller`, but if you try to use go-to-references on `staticObjectMarshaller`, it will still not show you any usages. That is because the actual binding is never used, since givens are looked up by type.


### My problem with this
Fundamentally, it's very confusing to have `use ...` clauses without a clear way to see where the `given ...` statement is which fills it. If one is experienced in Scala and givens, and certain of the lookup rules, one knows that it must come from one of the imports. But, the use of `import ...` of a `given` from an object instance gives no readable indication in code of where that happens, so there is still some guess-work and jumping around to check all the imports in the scope.
In general, the combination of value imports and `given`s is a bit of a hot mess that I would prefer to avoid.

### The idea of this change
This is the most minimal change I could think of, which at least puts a clue in `UriSerializer` of where the `given`s are imported.

### Further question that I don't know the answer to
I am not sure if we even need to use a `given` here. The question I have is if, after the first time `staticObjectMarshaller` has been resolved, does it stay around in memory until next time we try to resolve it with the same `Envri`, `EnvriConfig` and `CpVocab`?
Otherwise this code can be simplified a lot. I have made a PR for that approach here: github.com/ICOS-Carbon-Portal/meta/pull/326