### PR TITLE
Change download URL to use .zip file downloads from button

### DIFF
--- a/src/main/scala/se/lu/nateko/cp/meta/views/LandingPageHelpers.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/views/LandingPageHelpers.scala
@@ -100,6 +100,11 @@ object LandingPageHelpers:
 		s"""https://${conf.dataHost}/portal/#${params}"""
 	}
 
+	def getDownloadURL(dobj: DataObject)(using conf: EnvriConfig) = {
+		val query = urlEncode(s"""ids=["${dobj.hash.id}"]&fileName=${dobj.fileName.replaceAll("\\.[^.]*$", "")}""")
+		s"https://${conf.dataHost}/objects?${query}"
+	}
+
 	def renderMarkdown(md: String): String = {
 		val extensions = Iterable(AutolinkExtension.create()).asJava
 		val parser: Parser = Parser.builder().extensions(extensions).build()

--- a/src/main/twirl/views/landpagesnips/objPageHeaderExtra.scala.html
+++ b/src/main/twirl/views/landpagesnips/objPageHeaderExtra.scala.html
@@ -4,10 +4,8 @@
 
 @(dobj: DataObject)(implicit envriConf: EnvriConfig)
 <div class="d-flex gap-1 flex-shrink-0">
-	@dobj.accessUrl.map{link =>
-		<button id="meta-add-to-cart-button" class="btn btn-warning d-none" data-id="@{staticObjLandingPage(dobj.hash)}">Add to cart</button>
-		<button id="meta-remove-from-cart-button" class="btn btn-outline-secondary d-none" data-id="@{staticObjLandingPage(dobj.hash)}">Remove from cart</button>
-		<a class="btn btn-warning" href="@link">Download</a>
-	}
+	<button id="meta-add-to-cart-button" class="btn btn-warning d-none" data-id="@{staticObjLandingPage(dobj.hash)}">Add to cart</button>
+	<button id="meta-remove-from-cart-button" class="btn btn-outline-secondary d-none" data-id="@{staticObjLandingPage(dobj.hash)}">Remove from cart</button>
+	<a class="btn btn-warning" href='https://@{envriConf.dataHost}/objects?ids=%5B"@{dobj.hash.id}"%5D&fileName=@{dobj.fileName.replaceAll("\\.[^.]*$", "")}'>Download</a>
 </div>
 

--- a/src/main/twirl/views/landpagesnips/objPageHeaderExtra.scala.html
+++ b/src/main/twirl/views/landpagesnips/objPageHeaderExtra.scala.html
@@ -1,11 +1,12 @@
 @import se.lu.nateko.cp.meta.core.data.EnvriConfig
 @import se.lu.nateko.cp.meta.core.data.DataObject
 @import se.lu.nateko.cp.meta.core.data.staticObjLandingPage
+@import se.lu.nateko.cp.meta.views.LandingPageHelpers.getDownloadURL
 
 @(dobj: DataObject)(implicit envriConf: EnvriConfig)
 <div class="d-flex gap-1 flex-shrink-0">
 	<button id="meta-add-to-cart-button" class="btn btn-warning d-none" data-id="@{staticObjLandingPage(dobj.hash)}">Add to cart</button>
 	<button id="meta-remove-from-cart-button" class="btn btn-outline-secondary d-none" data-id="@{staticObjLandingPage(dobj.hash)}">Remove from cart</button>
-	<a class="btn btn-warning" href='https://@{envriConf.dataHost}/objects?ids=%5B"@{dobj.hash.id}"%5D&fileName=@{dobj.fileName.replaceAll("\\.[^.]*$", "")}'>Download</a>
+	<a class="btn btn-warning" href="@{getDownloadURL(dobj)}">Download</a>
 </div>
 


### PR DESCRIPTION
Follow-up from [data repo PR 393](https://github.com/ICOS-Carbon-Portal/data/pull/393).

The URL for the download button should be changed from `dataHost/object/HASH` to `dataHost/objects?ids=["HASH"]&fileName=filename`. The query parameters ought to be encoded in general, but our service specifically breaks if the square brackets are not encoded.

My initial change is not the best way (right way? most maintable or consistent way?) to achieve this. There should be a function added to `se.lu.nateko.cp.meta.core.data` that can be called, similarly to how `staticObjLandingPage` is called to populate `data-id` in the Add/Remove to cart buttons.

I tried to do this myself, but the URL encoding made it tricky, because the `urlEncode` defined in `meta.utils` is not available in this context; nor are the `akka` components needed to duplicate the function. I don't know quite enough about how Scala/Akka/meta work at this point to do that, but hopefully this is enough info for a backend developer to do it.

We would probably not want to alter the existing `staticObjAccessUrl` function, since it is used for the `uploadgui` to allow for uploaders to directly download the file back, but instead add a new one (e.g. `staticObjBatchAccessUrl`) that takes the `DataObject` (or `DataObject.hash` and `DataObject.fileName`) and then constructs the properly encoded URL.

Happy to work with someone else to get this done properly!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209841412600862