### PR TITLE
Display all documentation links together

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val metaCore = (project in file("core"))
 	.enablePlugins(IcosCpSbtCodeGenPlugin)
 	.settings(
 		name := "meta-core",
-		version := "0.7.23",
+		version := "0.7.24",
 		scalacOptions ++= commonScalacOptions,
 		libraryDependencies ++= Seq(
 			"io.spray"              %% "spray-json"                         % "1.3.6",

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
@@ -211,12 +211,16 @@ case class DataObject(
 	)
 
 	def documentation: Seq[PlainStaticObject] =
-		specification.documentation ++
-		acquisition.toSeq.flatMap(_.station.specificInfo match
+		val acquisitionDocs = acquisition.map(_.station.specificInfo).collect{
 			case sites: SitesStationSpecifics => sites.documentation
-			case _ => Seq.empty
-		) ++
-		production.toSeq.flatMap(_.documentation)
+		}.getOrElse(Seq.empty)
+
+		Seq.concat(
+			specification.documentation,
+			acquisitionDocs,
+			production.flatMap(_.documentation)
+		)
+	end documentation
 }
 
 case class DocObject(

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
@@ -209,6 +209,14 @@ case class DataObject(
 		spatioTemporal => spatioTemporal.variables.nonEmpty,
 		stationTimeSeries => stationTimeSeries.columns.nonEmpty
 	)
+
+	def documentation: Seq[PlainStaticObject] =
+		specification.documentation ++
+		acquisition.toSeq.flatMap(_.station.specificInfo match
+			case sites: SitesStationSpecifics => sites.documentation
+			case _ => Seq.empty
+		) ++
+		production.toSeq.flatMap(_.documentation)
 }
 
 case class DocObject(

--- a/src/main/twirl/views/DataLandingPage.scala.html
+++ b/src/main/twirl/views/DataLandingPage.scala.html
@@ -82,10 +82,7 @@
 			@resourceproperty("Data type", dobj.specification.self)
 			@property("Data level", dobj.specification.dataLevel.toString)
 
-			@documentationLink(dobj.specification.documentation)
-			@for(acquisition <- dobj.acquisition; documentation <- stationDocs(acquisition.station)){
-				@documentationLink(documentation)
-			}
+			@documentationLink(dobj.documentation)
 
 			@for(licence <- dobj.references.licence){
 				@licenceProperty(licence)
@@ -131,9 +128,6 @@
 				}
 				@for(source <- production.sources.sorted){
 					@resourceproperty("Source object", source.asUriResource)
-				}
-				@for(doc <- production.documentation){
-					@resourceproperty("Documentation", doc.asUriResource)
 				}
 			}
 
@@ -382,13 +376,6 @@
 			("ICOS Cities Data Portal", s"//${conf.dataHost}/portal")
 		)
 	)
-}
-
-@stationDocs(station: Station) = @{
-	station.specificInfo match {
-		case sites: SitesStationSpecifics => Some(sites.documentation)
-		case _ => None
-	}
 }
 
 @previewTab = {

--- a/src/main/twirl/views/landpagesnips/documentationLink.scala.html
+++ b/src/main/twirl/views/landpagesnips/documentationLink.scala.html
@@ -9,7 +9,7 @@
 				<span>
 					@for((document, i) <- documents.zipWithIndex){
 						@if(i > 0) {
-							<span>, </span>
+							<br>
 						} else {}
 						<a href=@{document.res.getRawPath}>@{document.name}</a>
 					}


### PR DESCRIPTION
The production documentation links are currently displayed in the production section, separately from the other documents. This change list them all together by using a new method that returns all documents for a given data object.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211438660683084