### PR TITLE
Make variable definition more flexible for level 3 datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ For the spatiotemporal data objects, the metadata package has the same general s
 	"forStation": "http://meta.icos-cp.eu/resources/stations/AS_SMR",
 	"samplingHeight": 50.5,
 	"customLandingPage": "http://www.bgc-jena.mpg.de/CarboScope/?ID=s99_v3.7",
-	"variables": ["co2flux_land", "co2flux_ocean"]
+	"variables": [
+		"https://meta.icos-cp.eu/resources/cpmeta/co2flux_land",
+		"https://meta.icos-cp.eu/resources/cpmeta/co2flux_ocean"
+	]
 }
 ```
 

--- a/src/main/scala/UploadDtos.scala
+++ b/src/main/scala/UploadDtos.scala
@@ -86,7 +86,7 @@ case class SpatioTemporalDto(
 	forStation: Option[URI],
 	samplingHeight: Option[Float],
 	customLandingPage: Option[URI],
-	variables: Option[Seq[String]]
+	variables: Option[Seq[URI]]
 )
 
 case class DataProductionDto(

--- a/src/main/scala/services/CpVocab.scala
+++ b/src/main/scala/services/CpVocab.scala
@@ -80,6 +80,7 @@ class CpVocab (val factory: ValueFactory)(using envriConfigs: EnvriConfigs) exte
 	def getSpatialCoverage(hash: Sha256Sum)(using Envri): IRI = getSpatialCoverage(UriId(hash.id))
 	def getSpatialCoverage(id: UriId)(using Envri) = getRelativeRaw(SpatCovPrefix + id.urlSafeString)
 	def getVarInfo(hash: Sha256Sum, varLabel: String)(using Envri) = getRelativeRaw(s"${VarInfoPrefix}${urlEncode(varLabel)}_${hash.id}")
+	def getVarInfo(hash: Sha256Sum, varUri: URI)(using Envri): IRI = getVarInfo(hash, UriId(varUri).urlSafeString)
 	def getPosition(pos: Position)(using Envri) = getRelativeRaw(s"position_${pos.lat6}_${pos.lon6}")
 
 	def getNextVersionColl(hash: Sha256Sum)(using Envri) = getRelativeRaw(NextVersionCollPrefix + hash.id)

--- a/src/main/scala/services/UploadDtoReader.scala
+++ b/src/main/scala/services/UploadDtoReader.scala
@@ -47,7 +47,7 @@ object UploadDtoReader{
 					samplingHeight = l3.samplingHeight,
 					production = dataProductionToDto(l3.productionInfo),
 					customLandingPage = dobj.accessUrl.filterNot(uri => uri.getPath.endsWith(dobj.hash.id)),
-					variables = l3.variables.map(_.map(_.label))
+					variables = l3.variables.map(_.map(_.model.uri.toString.split('/').last))
 				))
 				case Right(l2) => Right(StationTimeSeriesDto(
 					station = l2.acquisition.station.org.self.uri,

--- a/src/main/scala/services/UploadDtoReader.scala
+++ b/src/main/scala/services/UploadDtoReader.scala
@@ -47,7 +47,7 @@ object UploadDtoReader{
 					samplingHeight = l3.samplingHeight,
 					production = dataProductionToDto(l3.productionInfo),
 					customLandingPage = dobj.accessUrl.filterNot(uri => uri.getPath.endsWith(dobj.hash.id)),
-					variables = l3.variables.map(_.map(_.model.uri.toString.split('/').last))
+					variables = l3.variables.map(_.map(_.model.uri))
 				))
 				case Right(l2) => Right(StationTimeSeriesDto(
 					station = l2.acquisition.station.org.self.uri,

--- a/src/main/scala/services/upload/StatementsProducer.scala
+++ b/src/main/scala/services/upload/StatementsProducer.scala
@@ -263,8 +263,9 @@ class StatementsProducer(vocab: CpVocab, metaVocab: CpmetaVocab) {
 				Seq(makeSt(itemIri, metaVocab.hasSpatialCoverage, covUri.toRdf))
 
 
-	private def getL3VarInfoStatements(objIri: IRI, hash: Sha256Sum, varName: String)(using Envri): Seq[Statement] = {
-		val vUri = vocab.getVarInfo(hash, varName)
+	private def getL3VarInfoStatements(objIri: IRI, hash: Sha256Sum, varUri: URI)(using Envri): Seq[Statement] = {
+		val varName = UriId(varUri).urlSafeString
+		val vUri = vocab.getVarInfo(hash, varUri)
 		Seq(
 			makeSt(objIri, metaVocab.hasActualVariable, vUri),
 			makeSt(vUri, RDF.TYPE, metaVocab.variableInfoClass),

--- a/src/main/scala/services/upload/VarMetaLookup.scala
+++ b/src/main/scala/services/upload/VarMetaLookup.scala
@@ -23,7 +23,9 @@ class VarMetaLookup(varDefs: Seq[DatasetVariable]):
 
 	val plainMandatory = varDefs.filterNot(_.isOptional).flatMap(_.plain)
 
-	private val plainLookup: Map[String, VarMeta] = varDefs.flatMap(_.plain).map(vm => vm.label -> vm).toMap
+	private val plainLookup: Map[String, VarMeta] = varDefs.flatMap(_.plain).map{vm =>
+		vm.model.uri.toString.split('/').last -> vm
+	}.toMap
 
 	private val regexes = varDefs.filter(_.isRegex).sortBy(_.isOptional).map{
 		dv => new Regex(dv.title) -> dv

--- a/src/main/scala/services/upload/VarMetaLookup.scala
+++ b/src/main/scala/services/upload/VarMetaLookup.scala
@@ -1,6 +1,7 @@
 package se.lu.nateko.cp.meta.services.upload
 
 import se.lu.nateko.cp.meta.core.data.{UriResource, ValueType, VarMeta}
+import se.lu.nateko.cp.meta.api.UriId
 
 import java.net.URI
 import scala.util.matching.Regex
@@ -24,7 +25,7 @@ class VarMetaLookup(varDefs: Seq[DatasetVariable]):
 	val plainMandatory = varDefs.filterNot(_.isOptional).flatMap(_.plain)
 
 	private val plainLookup: Map[String, VarMeta] = varDefs.flatMap(_.plain).map{vm =>
-		vm.model.uri.toString.split('/').last -> vm
+		UriId(vm.model.uri).urlSafeString -> vm
 	}.toMap
 
 	private val regexes = varDefs.filter(_.isRegex).sortBy(_.isOptional).map{

--- a/src/main/scala/services/upload/VarMetaLookup.scala
+++ b/src/main/scala/services/upload/VarMetaLookup.scala
@@ -32,6 +32,8 @@ class VarMetaLookup(varDefs: Seq[DatasetVariable]):
 		dv => new Regex(dv.title) -> dv
 	}
 
+	def lookup(varUri: URI): Option[VarMeta] = plainLookup.get(UriId(varUri).urlSafeString)
+
 	def lookup(varName: String): Option[VarMeta] = plainLookup.get(varName).orElse:
 		regexes.collectFirst:
 			case (reg, dv) if reg.matches(varName) =>

--- a/src/main/scala/services/upload/validation/UploadValidator.scala
+++ b/src/main/scala/services/upload/validation/UploadValidator.scala
@@ -343,9 +343,9 @@ class UploadValidator(servers: DataObjectInstanceServers):
 					): dsSpec =>
 						val valTypeLookupV = metaReader.getValTypeLookup(dsSpec.self.uri.toRdf)
 						errors ++= valTypeLookupV.errors
-						for valTypeLookup <- valTypeLookupV; varName <- vars do
-							if valTypeLookup.lookup(varName).isEmpty then errors +=
-								s"Variable name '$varName' is not compatible with dataset specification ${dsSpec.self.uri}"
+						for valTypeLookup <- valTypeLookupV; varUri <- vars do
+							if valTypeLookup.lookup(varUri).isEmpty then errors +=
+								s"Variable URI '$varUri' is not compatible with dataset specification ${dsSpec.self.uri}"
 
 			case Right(stationMeta) =>
 				if spec.specificDatasetType != DatasetType.StationTimeSeries

--- a/src/main/twirl/views/UploadGuiPage.scala.html
+++ b/src/main/twirl/views/UploadGuiPage.scala.html
@@ -113,7 +113,7 @@
 								<select class="form-select" id="submitteridselect"></select>
 							</div>
 							<div class="mb-3">
-								<label class="form-label" for="new-update-radio">New item/Update</label>
+								<label class="form-label">New item/Update</label>
 								<div>
 									<div id="new-update-radio">
 										<div class="form-check form-check-inline">
@@ -147,7 +147,7 @@
 								</div>
 							</div>
 							<div class="mb-3">
-								<label class="form-label" for="file-type-radio">Item type</label>
+								<label class="form-label">Item type</label>
 								<div>
 									<div id="file-type-radio">
 										<div class="form-check form-check-inline">
@@ -218,7 +218,7 @@
 						<div class="card-body">
 							<h2>Data</h2>
 							<div class="mb-3">
-								<label class="form-label" for="level-radio">Level</label>
+								<label class="form-label">Level</label>
 								<div>
 									<div id="level-radio">
 										<div class="form-check form-check-inline">
@@ -391,11 +391,13 @@
 							@geoCovSelect("spattemp"){
 							}
 							<div class="mb-3" id="l3varinfo-form">
-								<label class="form-label" for="l3varadd-button">Previewable variables</label>
+								<label class="form-label">Previewable variables</label>
 								<button type="button" id="l3varadd-button" class="btn btn-secondary btn-sm" aria-label="Add variable"><i class="fas fa-plus"></i></button>
 								<div class="input-group l3varinfo-element" style="display: none;">
-									<input type="text" class="form-control varnameInput" placeholder="variable name">
-									<button type="button" class="btn btn-secondary varInfoButton" aria-label="Remove variable"><i class="fas fa-times"></i></button>
+									<select class="form-select varnameInput"></select>
+									<span class="input-group-child-wrapper">
+										<button type="button" class="btn btn-secondary varInfoButton" aria-label="Remove variable"><i class="fas fa-times"></i></button>
+									</span>
 								</div>
 							</div>
 							<div class="mb-3">
@@ -423,7 +425,7 @@
 									<datalist id="agent-list"></datalist>
 								</div>
 								<div class="mb-3">
-									<label class="form-label" for="contributors">Contributors</label>
+									<label class="form-label">Contributors</label>
 									<div id="contributors">
 										<div draggable="true" class="input-group data-list draggable" style="display: none;">
 											<span class="input-group-text"><i class="fas fa-grip-lines"></i></span>
@@ -510,7 +512,7 @@
 								</div>
 							</div>
 							<div class="mb-3">
-								<label class="form-label" for="document-authors">Authors</label>
+								<label class="form-label">Authors</label>
 								<div id="document-authors">
 									<div draggable="true" class="input-group data-list draggable" style="display: none;">
 										<span class="input-group-text"><i class="fas fa-grip-lines"></i></span>
@@ -635,5 +637,14 @@ write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscree
 	<div class="mb-3 @{lbl}geocov-element @{lbl}latlonbox-element">
 		<label class="form-label" for="@{lbl}geomaxlon">Max longitude</label>
 		<input id="@{lbl}geomaxlon" type="text" class="form-control">
+	</div>
+}
+
+@l3varInputs(selectId: String) = {
+	<div class="input-group l3varinfo-element">
+		<select class="form-select" id=@selectId></select>
+		<span class="input-group-child-wrapper" data-bs-toggle="popover" data-bs-trigger="hover">
+			<button type="button" class="btn btn-secondary varInfoButton" aria-label="Remove variable"><i class="fas fa-times"></i></button>
+		</span>
 	</div>
 }

--- a/src/test/scala/test/SpatioTemporalDtoJsonTests.scala
+++ b/src/test/scala/test/SpatioTemporalDtoJsonTests.scala
@@ -1,0 +1,54 @@
+package se.lu.nateko.cp.meta.test
+
+import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.meta.core.data.{TemporalCoverage, TimeInterval}
+import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, DataProductionDto, SpatioTemporalDto}
+import spray.json.*
+
+import java.net.URI
+import java.time.Instant
+import scala.language.unsafeNulls
+
+class SpatioTemporalDtoJsonTests extends AnyFunSpec with CpmetaJsonProtocol:
+
+	describe("SpatioTemporalDto JSON format"):
+		it("roundtrips variables as full URIs"):
+			val dto = SpatioTemporalDto(
+				title = "Spatial dataset",
+				description = Some("desc"),
+				spatial = URI("https://meta.icos-cp.eu/resources/latlonboxes/globalLatLonBox"),
+				temporal = TemporalCoverage(
+					interval = TimeInterval(
+						start = Instant.parse("2024-01-01T00:00:00Z").nn,
+						stop = Instant.parse("2024-12-31T23:59:59Z").nn
+					),
+					resolution = Some("hourly")
+				),
+				production = DataProductionDto(
+					creator = URI("https://meta.icos-cp.eu/resources/organizations/ETC"),
+					contributors = Seq.empty,
+					hostOrganization = None,
+					comment = None,
+					sources = None,
+					documentation = None,
+					creationDate = Instant.parse("2025-01-01T00:00:00Z").nn
+				),
+				forStation = None,
+				samplingHeight = None,
+				customLandingPage = None,
+				variables = Some(Seq(
+					URI("https://meta.icos-cp.eu/resources/cpmeta/ET_T"),
+					URI("https://meta.icos-cp.eu/resources/cpmeta/SWC_1_5_1")
+				))
+			)
+
+			val json = dto.toJson
+			val back = json.convertTo[SpatioTemporalDto]
+
+			assert(back === dto)
+			assert(
+				json.asJsObject.fields("variables") === JsArray(
+					JsString("https://meta.icos-cp.eu/resources/cpmeta/ET_T"),
+					JsString("https://meta.icos-cp.eu/resources/cpmeta/SWC_1_5_1")
+				)
+			)

--- a/src/test/scala/test/services/CpVocabVarInfoTests.scala
+++ b/src/test/scala/test/services/CpVocabVarInfoTests.scala
@@ -1,0 +1,29 @@
+package se.lu.nateko.cp.meta.test.services
+
+import eu.icoscp.envri.Envri
+import org.eclipse.rdf4j.repository.sail.SailRepository
+import org.eclipse.rdf4j.sail.memory.MemoryStore
+import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
+import se.lu.nateko.cp.meta.services.CpVocab
+import se.lu.nateko.cp.meta.test.TestConfig.given
+
+import java.net.URI
+import scala.language.unsafeNulls
+
+class CpVocabVarInfoTests extends AnyFunSpec:
+
+	given Envri = Envri.ICOS
+
+	describe("CpVocab variable info IRI generation"):
+		it("keeps UriId(url segment) as varinfo label token"):
+			val repo = new SailRepository(new MemoryStore)
+			val vocab = CpVocab(repo.getValueFactory.nn)
+			val hash = Sha256Sum.fromBase64Url("old_vJN69j6rRPKxTbJZckEa").get
+			val varUri = URI("https://meta.icos-cp.eu/resources/cpmeta/ET_T")
+
+			val varInfoFromUri = vocab.getVarInfo(hash, varUri)
+			val varInfoFromString = vocab.getVarInfo(hash, "ET_T")
+
+			assert(varInfoFromUri === varInfoFromString)
+			assert(CpVocab.VarInfo.unapply(varInfoFromUri).contains(hash -> "ET_T"))

--- a/src/test/scala/upload/L3UpdateWorkbench.scala
+++ b/src/test/scala/upload/L3UpdateWorkbench.scala
@@ -33,7 +33,7 @@ object L3UpdateWorkbench extends CpmetaJsonProtocol{
 		val l3 = dto.specificInfo.left.getOrElse(???)
 		val l3updated = l3.copy(
 			spatial = new URI("http://meta.icos-cp.eu/resources/latlonboxes/globalLatLonBox"),
-			variables = Some(Seq("emission")),
+			variables = Some(Seq(new URI("https://meta.icos-cp.eu/resources/cpmeta/emission"))),
 		)
 		dto.copy(
 			submitterId = "CP",

--- a/uploadgui/src/main/scala/Dtos.scala
+++ b/uploadgui/src/main/scala/Dtos.scala
@@ -36,4 +36,4 @@ case class SamplingPoint(uri: URI, latitude: Double, longitude: Double, name: St
 
 class SpatialCoverage(val uri: Option[URI], val label: String)
 
-case class DatasetVar(label: String, title: String, valueType: String, unit: String, isOptional: Boolean, isRegex: Boolean)
+case class DatasetVar(uri: URI, label: String, title: String, valueType: String, unit: String, isOptional: Boolean, isRegex: Boolean)

--- a/uploadgui/src/main/scala/PubSubEvent.scala
+++ b/uploadgui/src/main/scala/PubSubEvent.scala
@@ -11,6 +11,7 @@ final case class LevelSelected(level: Int) extends PubSubEvent
 final case class ObjSpecSelected(spec: ObjSpec) extends PubSubEvent
 
 final case class GotStationsList(stations: IndexedSeq[Station]) extends PubSubEvent
+final case class GotVariableList(variables: IndexedSeq[DatasetVar]) extends PubSubEvent
 final case class GotUploadDto(dto: UploadDto) extends PubSubEvent
 
 case object FormInputUpdated extends PubSubEvent

--- a/uploadgui/src/main/scala/SparqlQueries.scala
+++ b/uploadgui/src/main/scala/SparqlQueries.scala
@@ -179,7 +179,7 @@ object SparqlQueries {
 
 	private def datasetVarOrColQuery(dataset: URI, typ: String) = s"""prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 		|prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
-		|select ?label ?title ?valueType ?unit ?optional ?regex
+		|select ?var ?label ?title ?valueType ?unit ?optional ?regex
 		|where{
 		|	<$dataset> cpmeta:has${typ} ?var .
 		|	?var rdfs:label ?label; cpmeta:has${typ}Title ?title ; cpmeta:hasValueType ?valueTypeRes .
@@ -190,6 +190,7 @@ object SparqlQueries {
 		|}""".stripMargin
 
 	def toDatasetVar(b: Binding) = DatasetVar(
+		new URI(b("var")),
 		b("label"),
 		b("title"),
 		b("valueType"),

--- a/uploadgui/src/main/scala/UploadApp.scala
+++ b/uploadgui/src/main/scala/UploadApp.scala
@@ -25,13 +25,13 @@ object UploadApp {
 	private val loginBlock = new HtmlElements("#login-block")
 	private val formBlock = new HtmlElements("#form-block")
 	private val headerButtons = new HtmlElements("#header-buttons-container")
-	private val modal = getElementById[html.Div]("upload-help-modal").get
+	private val modal = getElementById[html.Div]("upload-help-modal")
 	val progressBar = new ProgressBar("#progress-bar")
-	private val alert = getElementById[html.Div]("alert-placeholder").get
+	private val alert = getElementById[html.Div]("alert-placeholder")
 
 	private def setIframeSrc(src: String): Unit =
 		val iframe = getElementById[dom.html.IFrame]("help-modal-iframe")
-		iframe.foreach(_.src = src)
+		iframe.src = src
 
 	modal.addEventListener("show.bs.modal", { _ =>
 		setIframeSrc("https://www.youtube.com/embed/8TpbRZPaTuU")
@@ -73,7 +73,7 @@ object UploadApp {
 	private def displayLoginButton(authHost: String): Unit = {
 		val url = URIUtils.encodeURI(dom.window.location.href)
 		val href = s"https://$authHost/login/?targetUrl=$url"
-		getElementById[html.Anchor]("login-button").get.setAttribute("href", href)
+		getElementById[html.Anchor]("login-button").setAttribute("href", href)
 		loginBlock.show()
 	}
 

--- a/uploadgui/src/main/scala/Utils.scala
+++ b/uploadgui/src/main/scala/Utils.scala
@@ -12,9 +12,9 @@ import org.scalajs.dom.Element
 object Utils {
 
 
-	def getElementById[T <: html.Element : ClassTag](id: String): Option[T] = document.getElementById(id) match{
-		case input: T => Some(input)
-		case _ => None
+	def getElementById[T <: html.Element : ClassTag](id: String): T = document.getElementById(id) match{
+		case input: T => input
+		case _ => throw new Exception(s"Missing #$id element")
 	}
 
 	def querySelector[T <: html.Element : ClassTag](parent: html.Element, selector: String): Option[T] = parent.querySelector(selector) match {

--- a/uploadgui/src/main/scala/formcomponents/DataList.scala
+++ b/uploadgui/src/main/scala/formcomponents/DataList.scala
@@ -21,7 +21,7 @@ object DataListInput {
 }
 
 class DataList[T](elemId: String, val labeller: T => String) {
-	private val list = getElementById[html.DataList](elemId).get
+	private val list = getElementById[html.DataList](elemId)
 	private var _values = IndexedSeq.empty[T]
 	private val valLookup = mutable.Map.empty[String, T]
 	protected val lookupIsActive: Boolean = true
@@ -65,7 +65,7 @@ class DataListForm[T](elemId: String, list: DataList[T], notifyUpdate: () => Uni
 		}
 	}
 
-	private val formDiv = getElementById[html.Div](elemId).get
+	private val formDiv = getElementById[html.Div](elemId)
 	private val template = querySelector[html.Div](formDiv, ".data-list").get
 	private var _ordId: Long = 0L
 	private val addButton = querySelector[html.Button](formDiv, "#add-element").get

--- a/uploadgui/src/main/scala/formcomponents/FileInput.scala
+++ b/uploadgui/src/main/scala/formcomponents/FileInput.scala
@@ -16,7 +16,7 @@ import se.lu.nateko.cp.meta.upload.Utils.*
 import se.lu.nateko.cp.meta.upload.UploadApp
 
 class FileInput(elemId: String, cb: () => Unit){
-	private val fileInput = getElementById[html.Input](elemId).get
+	private val fileInput = getElementById[html.Input](elemId)
 	private var _hash: Try[Sha256Sum] = file.flatMap(_ => fail("hashsum computing has not started yet"))
 	private var _lastModified: Double = 0
 

--- a/uploadgui/src/main/scala/formcomponents/FormComponents.scala
+++ b/uploadgui/src/main/scala/formcomponents/FormComponents.scala
@@ -18,7 +18,7 @@ import se.lu.nateko.cp.meta.core.data.OneOrSeq
 
 
 class FormElement(elemId: String) {
-	private val form = getElementById[html.Form](elemId).get
+	private val form = getElementById[html.Form](elemId)
 
 	def reset() = {
 		form.reset()
@@ -117,7 +117,7 @@ class DescriptionInput(elemId: String, cb: () => Unit) extends GenericOptionalIn
 class TextOptInput(elemId: String, cb: () => Unit) extends GenericOptionalInput[String](elemId, cb)(s => Try(Some(s)), _.toString())
 
 class Button(elemId: String, onClick: () => Unit){
-	private val button = getElementById[html.Button](elemId).get
+	private val button = getElementById[html.Button](elemId)
 	private var popover = initializeBootstrapPopover(button.parentElement)
 
 	def enable(): Unit =
@@ -173,7 +173,7 @@ class HtmlElements(selector: String) {
 }
 
 class TagCloud(elemId: String) {
-	private val div = getElementById[html.Div](elemId).get
+	private val div = getElementById[html.Div](elemId)
 
 	def setList(keywords: Seq[String]): Unit = {
 		div.innerHTML =
@@ -185,7 +185,7 @@ class TagCloud(elemId: String) {
 }
 
 class Modal(elemId: String) {
-	private val modal = getElementById[html.Div](elemId).get
+	private val modal = getElementById[html.Div](elemId)
 	private val title = querySelector[html.Heading](modal, ".modal-title").get
 	private val body = querySelector[html.Div](modal, ".modal-body").get
 
@@ -199,7 +199,7 @@ class Modal(elemId: String) {
 }
 
 class Checkbox(elemId: String, cb: (Boolean) => Unit) {
-	private val checkbox = getElementById[html.Input](elemId).get
+	private val checkbox = getElementById[html.Input](elemId)
 
 	def checked: Boolean = checkbox.checked
 	def check(): Unit = {
@@ -218,7 +218,7 @@ class Checkbox(elemId: String, cb: (Boolean) => Unit) {
 }
 
 class Text(elemId: String):
-	private val label = getElementById[html.Span](elemId).get
+	private val label = getElementById[html.Span](elemId)
 
 	def setText(text: String): Unit =
 		label.innerHTML = text

--- a/uploadgui/src/main/scala/formcomponents/GenericTextInput.scala
+++ b/uploadgui/src/main/scala/formcomponents/GenericTextInput.scala
@@ -14,7 +14,7 @@ private abstract class TextInputElement extends html.Object{
 }
 
 abstract class GenericTextInput[T](elemId: String, cb: () => Unit, init: Try[T])(parser: String => Try[T], serializer: T => String) {
-	private val input: TextInputElement = getElementById[html.Element](elemId).get.asInstanceOf[TextInputElement]
+	private val input: TextInputElement = getElementById[html.Element](elemId).asInstanceOf[TextInputElement]
 	private var _value: Try[T] = init
 
 	def value: Try[T] = _value

--- a/uploadgui/src/main/scala/formcomponents/GenericTextInput.scala
+++ b/uploadgui/src/main/scala/formcomponents/GenericTextInput.scala
@@ -14,7 +14,7 @@ private abstract class TextInputElement extends html.Object{
 }
 
 abstract class GenericTextInput[T](elemId: String, cb: () => Unit, init: Try[T])(parser: String => Try[T], serializer: T => String) {
-	private val input: TextInputElement = getElementById[TextInputElement](elemId)
+	private val input: TextInputElement = getElementById[html.Element](elemId).asInstanceOf[TextInputElement]
 	private var _value: Try[T] = init
 
 	def value: Try[T] = _value

--- a/uploadgui/src/main/scala/formcomponents/GenericTextInput.scala
+++ b/uploadgui/src/main/scala/formcomponents/GenericTextInput.scala
@@ -14,7 +14,7 @@ private abstract class TextInputElement extends html.Object{
 }
 
 abstract class GenericTextInput[T](elemId: String, cb: () => Unit, init: Try[T])(parser: String => Try[T], serializer: T => String) {
-	private val input: TextInputElement = getElementById[html.Element](elemId).asInstanceOf[TextInputElement]
+	private val input: TextInputElement = getElementById[TextInputElement](elemId)
 	private var _value: Try[T] = init
 
 	def value: Try[T] = _value

--- a/uploadgui/src/main/scala/formcomponents/L3VarInfoForm.scala
+++ b/uploadgui/src/main/scala/formcomponents/L3VarInfoForm.scala
@@ -72,7 +72,7 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 			querySelector[html.Select](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
 		}
 
-		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", _.label, _.uri.toString, false, notifyUpdate)
+		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", s => s"${s.label} (${s.title})", _.uri.toString, false, notifyUpdate)
 		varNameInput.setOptions(list)
 
 		div.style.display = ""

--- a/uploadgui/src/main/scala/formcomponents/L3VarInfoForm.scala
+++ b/uploadgui/src/main/scala/formcomponents/L3VarInfoForm.scala
@@ -4,14 +4,17 @@ import scala.util.{Try, Success}
 import org.scalajs.dom.html
 import se.lu.nateko.cp.meta.upload.Utils.*
 import scala.collection.mutable
+import se.lu.nateko.cp.meta.upload.DatasetVar
 
 class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 
-	def varInfos: Try[Option[Seq[String]]] = if(elems.isEmpty) Success(None) else Try{
+	var list: IndexedSeq[DatasetVar] = IndexedSeq.empty
+
+	def values: Try[Option[Seq[DatasetVar]]] = if(elems.isEmpty) Success(None) else Try{
 		Some(elems.map(_.varInfo.get).toIndexedSeq)
 	}
 
-	def setValues(vars: Option[Seq[String]]): Unit = {
+	def setValues(vars: Option[Seq[DatasetVar]]): Unit = {
 		elems.foreach(_.remove())
 		elems.clear()
 		vars.foreach{vdtos =>
@@ -23,7 +26,7 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 		}
 	}
 
-	private val formDiv = getElementById[html.Div](elemId).get
+	private val formDiv = getElementById[html.Div](elemId)
 	private val template = querySelector[html.Div](formDiv, ".l3varinfo-element").get
 	private var _ordId: Long = 0L
 
@@ -45,9 +48,9 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 
 	private class L3VarInfoInput{
 
-		def varInfo: Try[String] = varNameInput.value
+		def varInfo: Try[DatasetVar] = varNameInput.value.withMissingError("Missing variable name")
 
-		def setValue(varName: String): Unit = {
+		def setValue(varName: DatasetVar): Unit = {
 			varNameInput.value = varName
 		}
 
@@ -66,10 +69,11 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 		}
 
 		Seq("varnameInput").foreach{inputClass =>
-			querySelector[html.Input](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
+			querySelector[html.Select](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
 		}
 
-		private val varNameInput = new TextInput(s"varnameInput_$id", notifyUpdate, "variable name")
+		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", _.label, _.uri.toString, false, notifyUpdate)
+		varNameInput.setOptions(list)
 
 		div.style.display = ""
 

--- a/uploadgui/src/main/scala/formcomponents/L3VarInfoForm.scala
+++ b/uploadgui/src/main/scala/formcomponents/L3VarInfoForm.scala
@@ -72,7 +72,7 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 			querySelector[html.Select](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
 		}
 
-		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", s => s"${s.label} (${s.title})", _.uri.toString, false, notifyUpdate)
+		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", s => s"${s.label} [${s.title}]", _.uri.toString, false, notifyUpdate)
 		varNameInput.setOptions(list)
 
 		div.style.display = ""

--- a/uploadgui/src/main/scala/formcomponents/Radio.scala
+++ b/uploadgui/src/main/scala/formcomponents/Radio.scala
@@ -4,7 +4,7 @@ import se.lu.nateko.cp.meta.upload.Utils.*
 import org.scalajs.dom.html
 
 class Radio[T](elemId: String, cb: T => Unit, parser: String => Option[T], serializer: T => String) {
-	private val inputBlock: html.Element = getElementById[html.Element](elemId).get
+	private val inputBlock: html.Element = getElementById[html.Element](elemId)
 	private val inputs: Seq[html.Input] = querySelectorAll[html.Input](inputBlock, "input[type=radio]")
 
 	def value: Option[T] = selectedInput.flatMap(si => parser(si.value))

--- a/uploadgui/src/main/scala/formcomponents/Select.scala
+++ b/uploadgui/src/main/scala/formcomponents/Select.scala
@@ -4,11 +4,11 @@ import org.scalajs.dom.{html, document}
 import se.lu.nateko.cp.meta.upload.Utils.*
 
 class Select[T](elemId: String, labeller: T => String, titleMaker: T => String, autoselect: Boolean = false, cb: () => Unit = () => ()){
-	private val select = getElementById[html.Select](elemId).get
+	private val select = getElementById[html.Select](elemId)
 	private var _values: IndexedSeq[T] = IndexedSeq.empty
 
 	select.onchange = _ => cb()
-	getElementById[html.Form]("form-block").get.onreset = _ => {
+	getElementById[html.Form]("form-block").onreset = _ => {
 		select.selectedIndex = -1
 		cb()
 	}

--- a/uploadgui/src/main/scala/subforms/CollectionPanel.scala
+++ b/uploadgui/src/main/scala/subforms/CollectionPanel.scala
@@ -21,10 +21,9 @@ class CollectionPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSubBus
 	private val collectionDoc = new HashOptInput("colldoc", notifyUpdate)
 	private val spatialCovSelect = new GeoCoverageSelector(covs, "coll")
 
-	getElementById[html.Button]("rmCollGeoSelection").foreach: button =>
-		button.onclick = event =>
-			event.preventDefault()
-			spatialCovSelect.unselect()
+	getElementById[html.Button]("rmCollGeoSelection").onclick = event =>
+		event.preventDefault()
+		spatialCovSelect.unselect()
 
 	def resetForm(): Unit =
 		collectionTitle.reset()

--- a/uploadgui/src/main/scala/subforms/DataPanel.scala
+++ b/uploadgui/src/main/scala/subforms/DataPanel.scala
@@ -87,6 +87,11 @@ class DataPanel(
 			if(objSpec.isStationTimeSer && isNotAtcTimeSeries && isNotWdcgg && isNotNetCDF) nRowsInput.enable() else nRowsInput.disable()
 			if(objSpec.dataset.nonEmpty) varInfoButton.enable() else disableVarInfoButton()
 			dataTypeKeywords.setList(objSpec.keywords)
+			objSpec.dataset.foreach(dataset => {
+				whenDone(getVariables(dataset)) { variables =>
+					bus.publish(GotVariableList(variables))
+				}
+			})
 			bus.publish(ObjSpecSelected(objSpec))
 		}
 		notifyUpdate()

--- a/uploadgui/src/main/scala/subforms/PanelSubform.scala
+++ b/uploadgui/src/main/scala/subforms/PanelSubform.scala
@@ -5,12 +5,14 @@ import se.lu.nateko.cp.meta.upload.*
 import eu.icoscp.envri.Envri
 
 import scala.concurrent.Future
+import java.net.URI
 
 abstract class PanelSubform(selector: String)(using bus: PubSubBus) {
 	protected val htmlElements = new HtmlElements(selector)
 	protected def notifyUpdate(): Unit = bus.publish(FormInputUpdated)
 	private type AgentList = IndexedSeq[NamedUri]
 	private var peepsOrgsFut: Option[Future[(AgentList, AgentList)]] = None
+	private var variablesFut: Option[Future[IndexedSeq[DatasetVar]]] = None
 
 
 	def resetForm(): Unit
@@ -23,4 +25,12 @@ abstract class PanelSubform(selector: String)(using bus: PubSubBus) {
 		result
 	else
 		peepsOrgsFut.get
+
+	protected def getVariables(dataset: URI) = if variablesFut.isEmpty then
+		val result = Backend.getDatasetVariables(dataset)
+		variablesFut = Some(result)
+		result
+	else
+		variablesFut.get
+
 }

--- a/uploadgui/src/main/scala/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/subforms/SpatioTemporalPanel.scala
@@ -41,7 +41,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
 	)
 
-	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.label)))
+	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.title)))
 
 	private val titleInput = new TextInput("l3title", notifyUpdate, "elaborated product title")
 	private val descriptionInput = new DescriptionInput("l3descr", notifyUpdate)

--- a/uploadgui/src/main/scala/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/subforms/SpatioTemporalPanel.scala
@@ -7,11 +7,13 @@ import se.lu.nateko.cp.meta.SpatioTemporalDto
 import se.lu.nateko.cp.meta.UploadDto
 import se.lu.nateko.cp.meta.core.data.TemporalCoverage
 import se.lu.nateko.cp.meta.upload.*
+import se.lu.nateko.cp.meta.upload.UploadApp.whenDone
 
 import scala.util.Try
 
 import formcomponents.*
 import Utils.*
+import java.net.URI
 
 class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSubBus) extends PanelSubform(".l3-section"){
 
@@ -26,7 +28,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		prod <- productionDto;
 		customLanding <- externalPageInput.value;
 		height <- samplingHeightInput.value;
-		varInfo <- varInfoForm.varInfos
+		varInfo <- varInfoForm.values
 	yield SpatioTemporalDto(
 		title = title,
 		description = descr,
@@ -36,10 +38,10 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		samplingHeight = height,
 		production = prod,
 		customLandingPage = customLanding,
-		variables = varInfo
+		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
 	)
 
-	def varnames: Try[Option[Seq[String]]] = varInfoForm.varInfos
+	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.label)))
 
 	private val titleInput = new TextInput("l3title", notifyUpdate, "elaborated product title")
 	private val descriptionInput = new DescriptionInput("l3descr", notifyUpdate)
@@ -52,6 +54,8 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 	private val spatialCovSelect = new GeoCoverageSelector(covs, "spattemp")
 	private val varInfoForm = new L3VarInfoForm("l3varinfo-form", notifyUpdate)
 	private val externalPageInput = new UriOptInput("l3landingpage", notifyUpdate)
+	private var datasetSpec: Option[URI] = None
+	private var selsectedVars: Option[Seq[String]] = None
 
 	def resetForm(): Unit = {
 		Iterable(
@@ -68,7 +72,14 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		case ObjSpecSelected(spec) =>
 			if(spec.isSpatiotemporal) show() else hide()
 			if(spec.isNetCDF) varInfoForm.show() else varInfoForm.hide()
+			datasetSpec = spec.dataset
 		case GotStationsList(stations) => stationSelect.setOptions(stations)
+		case GotVariableList(variables) =>
+			varInfoForm.list = variables
+			selsectedVars.map { variables =>
+				varInfoForm.setValues(Some(variables.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+			}
+
 	}
 
 	private def handleDto(upDto: UploadDto): Unit = upDto match {
@@ -86,7 +97,15 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 				) stationSelect.value = stat
 				samplingHeightInput.value = spatTemp.samplingHeight
 				externalPageInput.value = spatTemp.customLandingPage
-				varInfoForm.setValues(spatTemp.variables)
+				selsectedVars = spatTemp.variables
+				spatTemp.variables.map { varUris =>
+					datasetSpec.map { dataset => 
+						whenDone(getVariables(dataset)) { variables =>
+							varInfoForm.list = variables
+							varInfoForm.setValues(Some(varUris.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+						}
+					}
+				}
 				spatialCovSelect.handleReceivedSpatialCoverage(Some(spatTemp.spatial))
 				show()
 			case _ =>

--- a/uploadgui/src/main/scala/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/subforms/SpatioTemporalPanel.scala
@@ -38,7 +38,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		samplingHeight = height,
 		production = prod,
 		customLandingPage = customLanding,
-		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
+		variables = varInfo.map(_.map(_.uri))
 	)
 
 	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.title)))
@@ -55,7 +55,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 	private val varInfoForm = new L3VarInfoForm("l3varinfo-form", notifyUpdate)
 	private val externalPageInput = new UriOptInput("l3landingpage", notifyUpdate)
 	private var datasetSpec: Option[URI] = None
-	private var selsectedVars: Option[Seq[String]] = None
+	private var selsectedVars: Option[Seq[URI]] = None
 
 	def resetForm(): Unit = {
 		Iterable(
@@ -77,7 +77,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		case GotVariableList(variables) =>
 			varInfoForm.list = variables
 			selsectedVars.map { variables =>
-				varInfoForm.setValues(Some(variables.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+				varInfoForm.setValues(Some(variables.flatMap(uri => varInfoForm.list.find(_.uri == uri))))
 			}
 
 	}
@@ -102,7 +102,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 					datasetSpec.map { dataset => 
 						whenDone(getVariables(dataset)) { variables =>
 							varInfoForm.list = variables
-							varInfoForm.setValues(Some(varUris.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+							varInfoForm.setValues(Some(varUris.flatMap(uri => varInfoForm.list.find(_.uri == uri))))
 						}
 					}
 				}

--- a/uploadgui/src/main/scala/subforms/StationTimeSeriesPanel.scala
+++ b/uploadgui/src/main/scala/subforms/StationTimeSeriesPanel.scala
@@ -57,10 +57,9 @@ class StationTimeSeriesPanel(covs: IndexedSeq[SpatialCoverage]) (using bus: PubS
 
 	private val customSamplingPoint = SamplingPoint(new URI(""), 0, 0, "Custom")
 
-	getElementById[html.Button]("rmL2GeoSelection").foreach: button =>
-		button.onclick = event =>
-			event.preventDefault()
-			spatialCovSelect.unselect()
+	getElementById[html.Button]("rmL2GeoSelection").onclick = event =>
+		event.preventDefault()
+		spatialCovSelect.unselect()
 
 	def resetForm(): Unit = {
 		resetPlaceInfo()


### PR DESCRIPTION
We would still use the label as the identifier to avoid having to migrate the current data. It should now be possible to define distinct variables that use the same title in the dataset. The upload form was updated to fetch a list of available variables, and use a select to pick the relevant ones.

- [ ] Fix https://github.com/ICOS-Carbon-Portal/meta/pull/341/changes#diff-e0507a33bf3feaa7de27a6b5f64826c69d9b7963adf888df8e8ec2e12274ee66R27 introducing a regression for datasets with columns, most likely because of some mismatch between label and uri for columns like https://metastaging.icos-cp.eu/resources/cpmeta/delta13co2PerMil. This was discovered when uploading https://metastaging.icos-cp.eu/objects/KYBvPB1juM-mFM516hsWnFd- where only some stdev columns were showing in the list.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210613579294295