### PR TITLE
Suggestion: Use Seq[T] instead of Option[Seq[T]] in UploadDtos

### DIFF
--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
@@ -108,7 +108,7 @@ case class SpatioTemporalMeta(
 	station: Option[Station],
 	samplingHeight: Option[Float],
 	productionInfo: DataProduction,
-	variables: Option[Seq[VarMeta]]
+	variables: Seq[VarMeta]
 ){
 	def acquisition: Option[DataAcquisition] = station.map{
 		DataAcquisition(_, None, Some(temporal.interval), None, None, samplingHeight)
@@ -166,7 +166,7 @@ case class DataObject(
 
 		val varsAndPosits = for
 			cols <- specificInfo.fold(
-				l3 => l3.variables,
+				l3 => Some(l3.variables),
 				l2 => l2.columns
 			).toSeq
 			col <- cols

--- a/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
+++ b/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala
@@ -86,7 +86,7 @@ case class StationTimeSeriesMeta(
 	productionInfo: Option[DataProduction],
 	nRows: Option[Int],
 	coverage: Option[GeoFeature],
-	columns: Option[Seq[VarMeta]]
+	columns: Seq[VarMeta]
 )
 
 case class ValueType(self: UriResource, quantityKind: Option[UriResource], unit: Option[String])
@@ -164,11 +164,12 @@ case class DataObject(
 			l2 => l2.coverage.orElse(l2.acquisition.coverage)
 		)
 
+		val cols = specificInfo.fold(
+			l3 => l3.variables,
+			l2 => l2.columns
+		)
+
 		val varsAndPosits = for
-			cols <- specificInfo.fold(
-				l3 => Some(l3.variables),
-				l2 => l2.columns
-			).toSeq
 			col <- cols
 			deps <- col.instrumentDeployments.toSeq
 			dep <- deps

--- a/src/main/scala/se/lu/nateko/cp/meta/UploadDtos.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/UploadDtos.scala
@@ -86,7 +86,7 @@ case class SpatioTemporalDto(
 	forStation: Option[URI],
 	samplingHeight: Option[Float],
 	customLandingPage: Option[URI],
-	variables: Option[Seq[String]]
+	variables: Seq[String]
 )
 
 case class DataProductionDto(

--- a/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
@@ -47,7 +47,7 @@ object UploadDtoReader{
 					samplingHeight = l3.samplingHeight,
 					production = dataProductionToDto(l3.productionInfo),
 					customLandingPage = dobj.accessUrl.filterNot(uri => uri.getPath.endsWith(dobj.hash.id)),
-					variables = l3.variables.map(_.map(_.label))
+					variables = l3.variables.map(_.map(_.model.uri.toString.split('/').last))
 				))
 				case Right(l2) => Right(StationTimeSeriesDto(
 					station = l2.acquisition.station.org.self.uri,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
@@ -47,7 +47,7 @@ object UploadDtoReader{
 					samplingHeight = l3.samplingHeight,
 					production = dataProductionToDto(l3.productionInfo),
 					customLandingPage = dobj.accessUrl.filterNot(uri => uri.getPath.endsWith(dobj.hash.id)),
-					variables = l3.variables.map(_.map(_.model.uri.toString.split('/').last)).getOrElse(Nil)
+					variables = l3.variables.map(_.model.uri.toString.split('/').last)
 				))
 				case Right(l2) => Right(StationTimeSeriesDto(
 					station = l2.acquisition.station.org.self.uri,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/UploadDtoReader.scala
@@ -47,7 +47,7 @@ object UploadDtoReader{
 					samplingHeight = l3.samplingHeight,
 					production = dataProductionToDto(l3.productionInfo),
 					customLandingPage = dobj.accessUrl.filterNot(uri => uri.getPath.endsWith(dobj.hash.id)),
-					variables = l3.variables.map(_.map(_.model.uri.toString.split('/').last))
+					variables = l3.variables.map(_.map(_.model.uri.toString.split('/').last)).getOrElse(Nil)
 				))
 				case Right(l2) => Right(StationTimeSeriesDto(
 					station = l2.acquisition.station.org.self.uri,

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/AttributionProvider.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/AttributionProvider.scala
@@ -65,10 +65,9 @@ final class AttributionProvider(vocab: CpVocab, val metaVocab: CpmetaVocab) exte
 		if(dobj.specification.theme.self.uri === vocab.atmoTheme) memb => (memb.role.weight.isDefined && {
 			val speciesOk = for(
 				extra <- memb.role.extra;
-				l2 <- dobj.specificInfo.toOption;
-				cols <- l2.columns
+				l2 <- dobj.specificInfo.toOption
 			) yield{
-				val colLabels = cols.map(_.label.toLowerCase)
+				val colLabels = l2.columns.map(_.label.toLowerCase)
 				extra.split(',').map(_.trim.toLowerCase).exists(species =>
 					colLabels.exists(_.contains(species)) ||
 					dobj.specification.self.label.getOrElse("").toLowerCase.contains(species)

--- a/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationMaker.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/citation/CitationMaker.scala
@@ -177,9 +177,11 @@ class CitationMaker(
 					val height = acq.samplingHeight.fold("")(sh => s" ($sh m)")
 					val vars =
 						if dobj.specification.self.uri === vocab.atmGhgProdSpec then
-							stationTs.columns.fold("")(_.collect{
-								case v if v.valueType.unit.isDefined => v.label
-							}.mkString(" (", ", ", ")"))
+							if (stationTs.columns.nonEmpty)
+								stationTs.columns.collect{
+									case v if v.valueType.unit.isDefined => v.label
+								}.mkString(" (", ", ", ")")
+							else ""
 						else ""
 
 					s"$spec$vars from $station$height"

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala
@@ -183,7 +183,7 @@ class SchemaOrg(handleProxies: HandleProxiesConfig)(using envri: Envri, envriCon
 			)
 		}
 
-		val variableMeasured = asOptArray(dobj.specificInfo.fold(spatio => Some(spatio.variables), timeSeries => timeSeries.columns))(
+		val variableMeasured = asOptArray(dobj.specificInfo.fold((_.variables), _.columns))(
 			variable => JsObject(
 				"@type"       -> JsString("PropertyValue"),
 				"name"        -> JsString(variable.label),

--- a/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala
@@ -183,7 +183,7 @@ class SchemaOrg(handleProxies: HandleProxiesConfig)(using envri: Envri, envriCon
 			)
 		}
 
-		val variableMeasured = asOptArray(dobj.specificInfo.fold(_.variables, _.columns))(
+		val variableMeasured = asOptArray(dobj.specificInfo.fold(spatio => Some(spatio.variables), timeSeries => timeSeries.columns))(
 			variable => JsObject(
 				"@type"       -> JsString("PropertyValue"),
 				"name"        -> JsString(variable.label),

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
@@ -325,7 +325,7 @@ trait DobjMetaReader(val vocab: CpVocab) extends CpmetaReader:
 				station = station,
 				samplingHeight = samplingHeightOpt.flatten,
 				productionInfo = prod,
-				variables = Some(variables.flatten).filterNot(_.isEmpty)
+				variables = variables.flatten()
 			)
 
 	def getContributors(objIri: IRI, contribPredicate: IRI)(using conn: DobjConn | DocConn): Validated[IndexedSeq[Agent]] = 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/DobjMetaReader.scala
@@ -272,7 +272,7 @@ trait DobjMetaReader(val vocab: CpVocab) extends CpmetaReader:
 						case Some(interval) =>
 							addInstrDeplInfo(stationUri, interval, columns)
 			columnsOptV.sinkOption.map: columnsOpt =>
-				StationTimeSeriesMeta(acq, prod, nRows, lblCoverage, columnsOpt)
+				StationTimeSeriesMeta(acq, prod, nRows, lblCoverage, columnsOpt.getOrElse(Nil))
 		resV.flatMap(identity)
 	end getStationTimeSerMeta
 

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/StatementsProducer.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/StatementsProducer.scala
@@ -201,7 +201,7 @@ class StatementsProducer(vocab: CpVocab, metaVocab: CpmetaVocab) {
 		makeSt(acq, metaVocab.prov.wasAssociatedWith, meta.forStation.map(_.toRdf)) ++
 		makeSt(acq, metaVocab.hasSamplingHeight, meta.samplingHeight.map(vocab.lit)) ++
 		makeSt(objUri, RDFS.SEEALSO, meta.customLandingPage.map(_.toRdf)) ++
-		meta.variables.toSeq.flatten.flatMap(getL3VarInfoStatements(objUri, hash, _))
+		meta.variables.flatMap(getL3VarInfoStatements(objUri, hash, _))
 	}
 
 	private def getStationDataStatements(hash: Sha256Sum, meta: StationTimeSeriesDto)(using Envri): Seq[Statement] = {

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/VarMetaLookup.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/VarMetaLookup.scala
@@ -23,7 +23,9 @@ class VarMetaLookup(varDefs: Seq[DatasetVariable]):
 
 	val plainMandatory = varDefs.filterNot(_.isOptional).flatMap(_.plain)
 
-	private val plainLookup: Map[String, VarMeta] = varDefs.flatMap(_.plain).map(vm => vm.label -> vm).toMap
+	private val plainLookup: Map[String, VarMeta] = varDefs.flatMap(_.plain).map{vm =>
+		vm.model.uri.toString.split('/').last -> vm
+	}.toMap
 
 	private val regexes = varDefs.filter(_.isRegex).sortBy(_.isOptional).map{
 		dv => new Regex(dv.title) -> dv

--- a/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/UploadValidator.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/services/upload/validation/UploadValidator.scala
@@ -338,14 +338,16 @@ class UploadValidator(servers: DataObjectInstanceServers):
 				if spec.specificDatasetType != DatasetType.SpatioTemporal
 				then errors += "Wrong type of dataset for this object spec (must be spatiotemporal)"
 				else
-					for vars <- spTempMeta.variables do spec.datasetSpec.fold(
-						errors += s"Data object specification ${spec.self.uri} lacks a dataset specification; cannot accept variable info."
-					): dsSpec =>
-						val valTypeLookupV = metaReader.getValTypeLookup(dsSpec.self.uri.toRdf)
-						errors ++= valTypeLookupV.errors
-						for valTypeLookup <- valTypeLookupV; varName <- vars do
-							if valTypeLookup.lookup(varName).isEmpty then errors +=
-								s"Variable name '$varName' is not compatible with dataset specification ${dsSpec.self.uri}"
+					if (spTempMeta.variables.nonEmpty) {
+						spec.datasetSpec.fold(
+							errors += s"Data object specification ${spec.self.uri} lacks a dataset specification; cannot accept variable info."
+						): dsSpec =>
+							val valTypeLookupV = metaReader.getValTypeLookup(dsSpec.self.uri.toRdf)
+							errors ++= valTypeLookupV.errors
+							for valTypeLookup <- valTypeLookupV; varName <- spTempMeta.variables do
+								if valTypeLookup.lookup(varName).isEmpty then errors +=
+									s"Variable name '$varName' is not compatible with dataset specification ${dsSpec.self.uri}"
+					}
 
 			case Right(stationMeta) =>
 				if spec.specificDatasetType != DatasetType.StationTimeSeries

--- a/src/main/twirl/views/DataLandingPage.scala.html
+++ b/src/main/twirl/views/DataLandingPage.scala.html
@@ -133,7 +133,7 @@
 
 			<br>
 
-			@for(variables <- varMetas){
+			@if(varMetas.nonEmpty){
 				<h2 class="fs-3 mt-5">Previewable variables</h2>
 				<div class="col-md-12 overflow-auto">
 				<table class="table">
@@ -155,7 +155,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						@for(varInfo <- variables){
+						@for(varInfo <- varMetas){
 							<tr>
 								<td>@(varInfo.label)</td>
 								<td>@(varInfo.valueType.self.label.getOrElse(""))</td>
@@ -398,11 +398,11 @@
 }
 
 @varMetas = @{
-	dobj.specificInfo.fold( spatio => Some(spatio.variables), timeSeries => timeSeries.columns)
+	dobj.specificInfo.fold(_.variables, _.columns)
 }
 
 @instrumentDeploymentsPresent = @{
-	varMetas.exists(_.exists(_.instrumentDeployments.isDefined))
+	varMetas.exists(_.instrumentDeployments.isDefined)
 }
 
 @moratoriumText = @{

--- a/src/main/twirl/views/DataLandingPage.scala.html
+++ b/src/main/twirl/views/DataLandingPage.scala.html
@@ -398,7 +398,7 @@
 }
 
 @varMetas = @{
-	dobj.specificInfo.fold(_.variables, _.columns)
+	dobj.specificInfo.fold( spatio => Some(spatio.variables), timeSeries => timeSeries.columns)
 }
 
 @instrumentDeploymentsPresent = @{

--- a/src/main/twirl/views/UploadGuiPage.scala.html
+++ b/src/main/twirl/views/UploadGuiPage.scala.html
@@ -113,7 +113,7 @@
 								<select class="form-select" id="submitteridselect"></select>
 							</div>
 							<div class="mb-3">
-								<label class="form-label" for="new-update-radio">New item/Update</label>
+								<label class="form-label">New item/Update</label>
 								<div>
 									<div id="new-update-radio">
 										<div class="form-check form-check-inline">
@@ -147,7 +147,7 @@
 								</div>
 							</div>
 							<div class="mb-3">
-								<label class="form-label" for="file-type-radio">Item type</label>
+								<label class="form-label">Item type</label>
 								<div>
 									<div id="file-type-radio">
 										<div class="form-check form-check-inline">
@@ -217,7 +217,7 @@
 						<div class="card-body">
 							<h2>Data</h2>
 							<div class="mb-3">
-								<label class="form-label" for="level-radio">Level</label>
+								<label class="form-label">Level</label>
 								<div>
 									<div id="level-radio">
 										<div class="form-check form-check-inline">
@@ -390,11 +390,13 @@
 							@geoCovSelect("spattemp"){
 							}
 							<div class="mb-3" id="l3varinfo-form">
-								<label class="form-label" for="l3varadd-button">Previewable variables</label>
+								<label class="form-label">Previewable variables</label>
 								<button type="button" id="l3varadd-button" class="btn btn-secondary btn-sm" aria-label="Add variable"><i class="fas fa-plus"></i></button>
 								<div class="input-group l3varinfo-element" style="display: none;">
-									<input type="text" class="form-control varnameInput" placeholder="variable name">
-									<button type="button" class="btn btn-secondary varInfoButton" aria-label="Remove variable"><i class="fas fa-times"></i></button>
+									<select class="form-select varnameInput"></select>
+									<span class="input-group-child-wrapper">
+										<button type="button" class="btn btn-secondary varInfoButton" aria-label="Remove variable"><i class="fas fa-times"></i></button>
+									</span>
 								</div>
 							</div>
 							<div class="mb-3">
@@ -422,7 +424,7 @@
 									<datalist id="agent-list"></datalist>
 								</div>
 								<div class="mb-3">
-									<label class="form-label" for="contributors">Contributors</label>
+									<label class="form-label">Contributors</label>
 									<div id="contributors">
 										<div draggable="true" class="input-group data-list draggable" style="display: none;">
 											<span class="input-group-text"><i class="fas fa-grip-lines"></i></span>
@@ -509,7 +511,7 @@
 								</div>
 							</div>
 							<div class="mb-3">
-								<label class="form-label" for="document-authors">Authors</label>
+								<label class="form-label">Authors</label>
 								<div id="document-authors">
 									<div draggable="true" class="input-group data-list draggable" style="display: none;">
 										<span class="input-group-text"><i class="fas fa-grip-lines"></i></span>
@@ -634,5 +636,14 @@ write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscree
 	<div class="mb-3 @{lbl}geocov-element @{lbl}latlonbox-element">
 		<label class="form-label" for="@{lbl}geomaxlon">Max longitude</label>
 		<input id="@{lbl}geomaxlon" type="text" class="form-control">
+	</div>
+}
+
+@l3varInputs(selectId: String) = {
+	<div class="input-group l3varinfo-element">
+		<select class="form-select" id=@selectId></select>
+		<span class="input-group-child-wrapper" data-bs-toggle="popover" data-bs-trigger="hover">
+			<button type="button" class="btn btn-secondary varInfoButton" aria-label="Remove variable"><i class="fas fa-times"></i></button>
+		</span>
 	</div>
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/upload/L3UpdateWorkbench.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/upload/L3UpdateWorkbench.scala
@@ -33,7 +33,7 @@ object L3UpdateWorkbench extends CpmetaJsonProtocol{
 		val l3 = dto.specificInfo.left.getOrElse(???)
 		val l3updated = l3.copy(
 			spatial = new URI("http://meta.icos-cp.eu/resources/latlonboxes/globalLatLonBox"),
-			variables = Some(Seq("emission")),
+			variables = Seq("emission"),
 		)
 		dto.copy(
 			submitterId = "CP",

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
@@ -99,7 +99,9 @@ object Backend {
 		file: File, spec: ObjSpec, nRows: Option[Int], varnames: Seq[String]
 	)(implicit envriConfig: EnvriConfig): Future[Unit] = {
 
-		if (spec.dataset.isDefined && (spec.isStationTimeSer || varnames.nonEmpty)) || spec.isZip || spec.isNetCDF then
+		val hasVars = varnames.nonEmpty
+
+		if (spec.dataset.isDefined && (spec.isStationTimeSer || hasVars)) || spec.isZip || spec.isNetCDF then
 
 			val nRowsQ = nRows.fold("")(nr => s"&nRows=$nr")
 			val varsQ = if (varnames.nonEmpty) {

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
@@ -102,8 +102,10 @@ object Backend {
 		if (spec.dataset.isDefined && (spec.isStationTimeSer || varnames.nonEmpty)) || spec.isZip || spec.isNetCDF then
 
 			val nRowsQ = nRows.fold("")(nr => s"&nRows=$nr")
-			val varsJson = encodeURIComponent(Json.toJson(varnames).toString)
-			val varsQ = s"&varnames=$varsJson"
+			val varsQ = if (varnames.nonEmpty) {
+				val varsJson = encodeURIComponent(Json.toJson(varnames).toString)
+				s"&varnames=$varsJson"
+			} else { "" }
 
 			val url = s"https://${envriConfig.dataHost}/tryingest?specUri=${spec.uri}$nRowsQ$varsQ"
 			fetchOk("validate data object", url, new RequestInit{

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Backend.scala
@@ -96,18 +96,14 @@ object Backend {
 		sparqlSelect(datasetVariableQuery(dataset)).map(_.map(toDatasetVar))
 
 	def tryIngestion(
-		file: File, spec: ObjSpec, nRows: Option[Int], varnames: Option[Seq[String]]
+		file: File, spec: ObjSpec, nRows: Option[Int], varnames: Seq[String]
 	)(implicit envriConfig: EnvriConfig): Future[Unit] = {
 
-		val hasVars: Boolean = varnames.flatMap(_.headOption).isDefined
-
-		if (spec.dataset.isDefined && (spec.isStationTimeSer || hasVars)) || spec.isZip || spec.isNetCDF then
+		if (spec.dataset.isDefined && (spec.isStationTimeSer || varnames.nonEmpty)) || spec.isZip || spec.isNetCDF then
 
 			val nRowsQ = nRows.fold("")(nr => s"&nRows=$nr")
-			val varsQ = varnames.fold(""){vns =>
-				val varsJson = encodeURIComponent(Json.toJson(vns).toString)
-				s"&varnames=$varsJson"
-			}
+			val varsJson = encodeURIComponent(Json.toJson(varnames).toString)
+			val varsQ = s"&varnames=$varsJson"
 
 			val url = s"https://${envriConfig.dataHost}/tryingest?specUri=${spec.uri}$nRowsQ$varsQ"
 			fetchOk("validate data object", url, new RequestInit{

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Dtos.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Dtos.scala
@@ -36,4 +36,4 @@ case class SamplingPoint(uri: URI, latitude: Double, longitude: Double, name: St
 
 class SpatialCoverage(val uri: Option[URI], val label: String)
 
-case class DatasetVar(label: String, title: String, valueType: String, unit: String, isOptional: Boolean, isRegex: Boolean)
+case class DatasetVar(uri: URI, label: String, title: String, valueType: String, unit: String, isOptional: Boolean, isRegex: Boolean)

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/PubSubEvent.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/PubSubEvent.scala
@@ -11,6 +11,7 @@ final case class LevelSelected(level: Int) extends PubSubEvent
 final case class ObjSpecSelected(spec: ObjSpec) extends PubSubEvent
 
 final case class GotStationsList(stations: IndexedSeq[Station]) extends PubSubEvent
+final case class GotVariableList(variables: IndexedSeq[DatasetVar]) extends PubSubEvent
 final case class GotUploadDto(dto: UploadDto) extends PubSubEvent
 
 case object FormInputUpdated extends PubSubEvent

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/SparqlQueries.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/SparqlQueries.scala
@@ -179,7 +179,7 @@ object SparqlQueries {
 
 	private def datasetVarOrColQuery(dataset: URI, typ: String) = s"""prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 		|prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
-		|select ?label ?title ?valueType ?unit ?optional ?regex
+		|select ?var ?label ?title ?valueType ?unit ?optional ?regex
 		|where{
 		|	<$dataset> cpmeta:has${typ} ?var .
 		|	?var rdfs:label ?label; cpmeta:has${typ}Title ?title ; cpmeta:hasValueType ?valueTypeRes .
@@ -190,6 +190,7 @@ object SparqlQueries {
 		|}""".stripMargin
 
 	def toDatasetVar(b: Binding) = DatasetVar(
+		new URI(b("var")),
 		b("label"),
 		b("title"),
 		b("valueType"),

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/UploadApp.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/UploadApp.scala
@@ -25,13 +25,13 @@ object UploadApp {
 	private val loginBlock = new HtmlElements("#login-block")
 	private val formBlock = new HtmlElements("#form-block")
 	private val headerButtons = new HtmlElements("#header-buttons-container")
-	private val modal = getElementById[html.Div]("upload-help-modal").get
+	private val modal = getElementById[html.Div]("upload-help-modal")
 	val progressBar = new ProgressBar("#progress-bar")
-	private val alert = getElementById[html.Div]("alert-placeholder").get
+	private val alert = getElementById[html.Div]("alert-placeholder")
 
 	private def setIframeSrc(src: String): Unit =
 		val iframe = getElementById[dom.html.IFrame]("help-modal-iframe")
-		iframe.foreach(_.src = src)
+		iframe.src = src
 
 	modal.addEventListener("show.bs.modal", { _ =>
 		setIframeSrc("https://www.youtube.com/embed/8TpbRZPaTuU")
@@ -73,7 +73,7 @@ object UploadApp {
 	private def displayLoginButton(authHost: String): Unit = {
 		val url = URIUtils.encodeURI(dom.window.location.href)
 		val href = s"https://$authHost/login/?targetUrl=$url"
-		getElementById[html.Anchor]("login-button").get.setAttribute("href", href)
+		getElementById[html.Anchor]("login-button").setAttribute("href", href)
 		loginBlock.show()
 	}
 

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Utils.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/Utils.scala
@@ -12,9 +12,9 @@ import org.scalajs.dom.Element
 object Utils {
 
 
-	def getElementById[T <: html.Element : ClassTag](id: String): Option[T] = document.getElementById(id) match{
-		case input: T => Some(input)
-		case _ => None
+	def getElementById[T <: html.Element : ClassTag](id: String): T = document.getElementById(id) match{
+		case input: T => input
+		case _ => throw new Exception(s"Missing #$id element")
 	}
 
 	def querySelector[T <: html.Element : ClassTag](parent: html.Element, selector: String): Option[T] = parent.querySelector(selector) match {

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/DataList.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/DataList.scala
@@ -21,7 +21,7 @@ object DataListInput {
 }
 
 class DataList[T](elemId: String, val labeller: T => String) {
-	private val list = getElementById[html.DataList](elemId).get
+	private val list = getElementById[html.DataList](elemId)
 	private var _values = IndexedSeq.empty[T]
 	private val valLookup = mutable.Map.empty[String, T]
 	protected val lookupIsActive: Boolean = true
@@ -65,7 +65,7 @@ class DataListForm[T](elemId: String, list: DataList[T], notifyUpdate: () => Uni
 		}
 	}
 
-	private val formDiv = getElementById[html.Div](elemId).get
+	private val formDiv = getElementById[html.Div](elemId)
 	private val template = querySelector[html.Div](formDiv, ".data-list").get
 	private var _ordId: Long = 0L
 	private val addButton = querySelector[html.Button](formDiv, "#add-element").get

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/FileInput.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/FileInput.scala
@@ -16,7 +16,7 @@ import se.lu.nateko.cp.meta.upload.Utils.*
 import se.lu.nateko.cp.meta.upload.UploadApp
 
 class FileInput(elemId: String, cb: () => Unit){
-	private val fileInput = getElementById[html.Input](elemId).get
+	private val fileInput = getElementById[html.Input](elemId)
 	private var _hash: Try[Sha256Sum] = file.flatMap(_ => fail("hashsum computing has not started yet"))
 	private var _lastModified: Double = 0
 

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/FormComponents.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/FormComponents.scala
@@ -18,7 +18,7 @@ import se.lu.nateko.cp.meta.core.data.OneOrSeq
 
 
 class FormElement(elemId: String) {
-	private val form = getElementById[html.Form](elemId).get
+	private val form = getElementById[html.Form](elemId)
 
 	def reset() = {
 		form.reset()
@@ -117,7 +117,7 @@ class DescriptionInput(elemId: String, cb: () => Unit) extends GenericOptionalIn
 class TextOptInput(elemId: String, cb: () => Unit) extends GenericOptionalInput[String](elemId, cb)(s => Try(Some(s)), _.toString())
 
 class Button(elemId: String, onClick: () => Unit){
-	private val button = getElementById[html.Button](elemId).get
+	private val button = getElementById[html.Button](elemId)
 	private var popover = initializeBootstrapPopover(button.parentElement)
 
 	def enable(): Unit =
@@ -173,7 +173,7 @@ class HtmlElements(selector: String) {
 }
 
 class TagCloud(elemId: String) {
-	private val div = getElementById[html.Div](elemId).get
+	private val div = getElementById[html.Div](elemId)
 
 	def setList(keywords: Seq[String]): Unit = {
 		div.innerHTML =
@@ -185,7 +185,7 @@ class TagCloud(elemId: String) {
 }
 
 class Modal(elemId: String) {
-	private val modal = getElementById[html.Div](elemId).get
+	private val modal = getElementById[html.Div](elemId)
 	private val title = querySelector[html.Heading](modal, ".modal-title").get
 	private val body = querySelector[html.Div](modal, ".modal-body").get
 
@@ -199,7 +199,7 @@ class Modal(elemId: String) {
 }
 
 class Checkbox(elemId: String, cb: (Boolean) => Unit) {
-	private val checkbox = getElementById[html.Input](elemId).get
+	private val checkbox = getElementById[html.Input](elemId)
 
 	def checked: Boolean = checkbox.checked
 	def check(): Unit = {
@@ -218,7 +218,7 @@ class Checkbox(elemId: String, cb: (Boolean) => Unit) {
 }
 
 class Text(elemId: String):
-	private val label = getElementById[html.Span](elemId).get
+	private val label = getElementById[html.Span](elemId)
 
 	def setText(text: String): Unit =
 		label.innerHTML = text

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/GenericTextInput.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/GenericTextInput.scala
@@ -14,7 +14,7 @@ private abstract class TextInputElement extends html.Object{
 }
 
 abstract class GenericTextInput[T](elemId: String, cb: () => Unit, init: Try[T])(parser: String => Try[T], serializer: T => String) {
-	private val input: TextInputElement = getElementById[html.Element](elemId).get.asInstanceOf[TextInputElement]
+	private val input: TextInputElement = getElementById[html.Element](elemId).asInstanceOf[TextInputElement]
 	private var _value: Try[T] = init
 
 	def value: Try[T] = _value

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/L3VarInfoForm.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/L3VarInfoForm.scala
@@ -72,7 +72,7 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 			querySelector[html.Select](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
 		}
 
-		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", _.label, _.uri.toString, false, notifyUpdate)
+		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", s => s"${s.label} (${s.title})", _.uri.toString, false, notifyUpdate)
 		varNameInput.setOptions(list)
 
 		div.style.display = ""

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/L3VarInfoForm.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/L3VarInfoForm.scala
@@ -4,14 +4,17 @@ import scala.util.{Try, Success}
 import org.scalajs.dom.html
 import se.lu.nateko.cp.meta.upload.Utils.*
 import scala.collection.mutable
+import se.lu.nateko.cp.meta.upload.DatasetVar
 
 class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 
-	def varInfos: Try[Option[Seq[String]]] = if(elems.isEmpty) Success(None) else Try{
+	var list: IndexedSeq[DatasetVar] = IndexedSeq.empty
+
+	def values: Try[Option[Seq[DatasetVar]]] = if(elems.isEmpty) Success(None) else Try{
 		Some(elems.map(_.varInfo.get).toIndexedSeq)
 	}
 
-	def setValues(vars: Option[Seq[String]]): Unit = {
+	def setValues(vars: Option[Seq[DatasetVar]]): Unit = {
 		elems.foreach(_.remove())
 		elems.clear()
 		vars.foreach{vdtos =>
@@ -23,7 +26,7 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 		}
 	}
 
-	private val formDiv = getElementById[html.Div](elemId).get
+	private val formDiv = getElementById[html.Div](elemId)
 	private val template = querySelector[html.Div](formDiv, ".l3varinfo-element").get
 	private var _ordId: Long = 0L
 
@@ -45,9 +48,9 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 
 	private class L3VarInfoInput{
 
-		def varInfo: Try[String] = varNameInput.value
+		def varInfo: Try[DatasetVar] = varNameInput.value.withMissingError("Missing variable name")
 
-		def setValue(varName: String): Unit = {
+		def setValue(varName: DatasetVar): Unit = {
 			varNameInput.value = varName
 		}
 
@@ -66,10 +69,11 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 		}
 
 		Seq("varnameInput").foreach{inputClass =>
-			querySelector[html.Input](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
+			querySelector[html.Select](div, s".$inputClass").foreach{_.id = s"${inputClass}_$id"}
 		}
 
-		private val varNameInput = new TextInput(s"varnameInput_$id", notifyUpdate, "variable name")
+		private val varNameInput = new Select[DatasetVar](s"varnameInput_$id", _.label, _.uri.toString, false, notifyUpdate)
+		varNameInput.setOptions(list)
 
 		div.style.display = ""
 

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/L3VarInfoForm.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/L3VarInfoForm.scala
@@ -10,19 +10,17 @@ class L3VarInfoForm(elemId: String, notifyUpdate: () => Unit) {
 
 	var list: IndexedSeq[DatasetVar] = IndexedSeq.empty
 
-	def values: Try[Option[Seq[DatasetVar]]] = if(elems.isEmpty) Success(None) else Try{
-		Some(elems.map(_.varInfo.get).toIndexedSeq)
+	def values: Try[Seq[DatasetVar]] = if(elems.isEmpty) Success(Nil) else Try{
+		elems.map(_.varInfo.get).toIndexedSeq
 	}
 
-	def setValues(vars: Option[Seq[DatasetVar]]): Unit = {
+	def setValues(vars: Seq[DatasetVar]): Unit = {
 		elems.foreach(_.remove())
 		elems.clear()
-		vars.foreach{vdtos =>
-			vdtos.foreach{vdto =>
-				val input = new L3VarInfoInput
-				input.setValue(vdto)
-				elems.append(input)
-			}
+		vars.foreach{vdto =>
+			val input = new L3VarInfoInput
+			input.setValue(vdto)
+			elems.append(input)
 		}
 	}
 

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/Radio.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/Radio.scala
@@ -4,7 +4,7 @@ import se.lu.nateko.cp.meta.upload.Utils.*
 import org.scalajs.dom.html
 
 class Radio[T](elemId: String, cb: T => Unit, parser: String => Option[T], serializer: T => String) {
-	private val inputBlock: html.Element = getElementById[html.Element](elemId).get
+	private val inputBlock: html.Element = getElementById[html.Element](elemId)
 	private val inputs: Seq[html.Input] = querySelectorAll[html.Input](inputBlock, "input[type=radio]")
 
 	def value: Option[T] = selectedInput.flatMap(si => parser(si.value))

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/Select.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/formcomponents/Select.scala
@@ -4,11 +4,11 @@ import org.scalajs.dom.{html, document}
 import se.lu.nateko.cp.meta.upload.Utils.*
 
 class Select[T](elemId: String, labeller: T => String, titleMaker: T => String, autoselect: Boolean = false, cb: () => Unit = () => ()){
-	private val select = getElementById[html.Select](elemId).get
+	private val select = getElementById[html.Select](elemId)
 	private var _values: IndexedSeq[T] = IndexedSeq.empty
 
 	select.onchange = _ => cb()
-	getElementById[html.Form]("form-block").get.onreset = _ => {
+	getElementById[html.Form]("form-block").onreset = _ => {
 		select.selectedIndex = -1
 		cb()
 	}

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/CollectionPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/CollectionPanel.scala
@@ -21,10 +21,9 @@ class CollectionPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSubBus
 	private val collectionDoc = new HashOptInput("colldoc", notifyUpdate)
 	private val spatialCovSelect = new GeoCoverageSelector(covs, "coll")
 
-	getElementById[html.Button]("rmCollGeoSelection").foreach: button =>
-		button.onclick = event =>
-			event.preventDefault()
-			spatialCovSelect.unselect()
+	getElementById[html.Button]("rmCollGeoSelection").onclick = event =>
+		event.preventDefault()
+		spatialCovSelect.unselect()
 
 	def resetForm(): Unit =
 		collectionTitle.reset()

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/DataPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/DataPanel.scala
@@ -87,6 +87,11 @@ class DataPanel(
 			if(objSpec.isStationTimeSer && isNotAtcTimeSeries && isNotWdcgg && isNotNetCDF) nRowsInput.enable() else nRowsInput.disable()
 			if(objSpec.dataset.nonEmpty) varInfoButton.enable() else disableVarInfoButton()
 			dataTypeKeywords.setList(objSpec.keywords)
+			objSpec.dataset.foreach(dataset => {
+				whenDone(getVariables(dataset)) { variables =>
+					bus.publish(GotVariableList(variables))
+				}
+			})
 			bus.publish(ObjSpecSelected(objSpec))
 		}
 		notifyUpdate()

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/PanelSubform.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/PanelSubform.scala
@@ -5,12 +5,14 @@ import se.lu.nateko.cp.meta.upload.*
 import eu.icoscp.envri.Envri
 
 import scala.concurrent.Future
+import java.net.URI
 
 abstract class PanelSubform(selector: String)(using bus: PubSubBus) {
 	protected val htmlElements = new HtmlElements(selector)
 	protected def notifyUpdate(): Unit = bus.publish(FormInputUpdated)
 	private type AgentList = IndexedSeq[NamedUri]
 	private var peepsOrgsFut: Option[Future[(AgentList, AgentList)]] = None
+	private var variablesFut: Option[Future[IndexedSeq[DatasetVar]]] = None
 
 
 	def resetForm(): Unit
@@ -23,4 +25,12 @@ abstract class PanelSubform(selector: String)(using bus: PubSubBus) {
 		result
 	else
 		peepsOrgsFut.get
+
+	protected def getVariables(dataset: URI) = if variablesFut.isEmpty then
+		val result = Backend.getDatasetVariables(dataset)
+		variablesFut = Some(result)
+		result
+	else
+		variablesFut.get
+
 }

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
@@ -41,7 +41,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
 	)
 
-	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.label)))
+	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.title)))
 
 	private val titleInput = new TextInput("l3title", notifyUpdate, "elaborated product title")
 	private val descriptionInput = new DescriptionInput("l3descr", notifyUpdate)

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
@@ -7,11 +7,13 @@ import se.lu.nateko.cp.meta.SpatioTemporalDto
 import se.lu.nateko.cp.meta.UploadDto
 import se.lu.nateko.cp.meta.core.data.TemporalCoverage
 import se.lu.nateko.cp.meta.upload.*
+import se.lu.nateko.cp.meta.upload.UploadApp.whenDone
 
 import scala.util.Try
 
 import formcomponents.*
 import Utils.*
+import java.net.URI
 
 class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSubBus) extends PanelSubform(".l3-section"){
 
@@ -26,7 +28,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		prod <- productionDto;
 		customLanding <- externalPageInput.value;
 		height <- samplingHeightInput.value;
-		varInfo <- varInfoForm.varInfos
+		varInfo <- varInfoForm.values
 	yield SpatioTemporalDto(
 		title = title,
 		description = descr,
@@ -36,10 +38,10 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		samplingHeight = height,
 		production = prod,
 		customLandingPage = customLanding,
-		variables = varInfo
+		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
 	)
 
-	def varnames: Try[Option[Seq[String]]] = varInfoForm.varInfos
+	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.label)))
 
 	private val titleInput = new TextInput("l3title", notifyUpdate, "elaborated product title")
 	private val descriptionInput = new DescriptionInput("l3descr", notifyUpdate)
@@ -52,6 +54,8 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 	private val spatialCovSelect = new GeoCoverageSelector(covs, "spattemp")
 	private val varInfoForm = new L3VarInfoForm("l3varinfo-form", notifyUpdate)
 	private val externalPageInput = new UriOptInput("l3landingpage", notifyUpdate)
+	private var datasetSpec: Option[URI] = None
+	private var selsectedVars: Option[Seq[String]] = None
 
 	def resetForm(): Unit = {
 		Iterable(
@@ -68,7 +72,14 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		case ObjSpecSelected(spec) =>
 			if(spec.isSpatiotemporal) show() else hide()
 			if(spec.isNetCDF) varInfoForm.show() else varInfoForm.hide()
+			datasetSpec = spec.dataset
 		case GotStationsList(stations) => stationSelect.setOptions(stations)
+		case GotVariableList(variables) =>
+			varInfoForm.list = variables
+			selsectedVars.map { variables =>
+				varInfoForm.setValues(Some(variables.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+			}
+
 	}
 
 	private def handleDto(upDto: UploadDto): Unit = upDto match {
@@ -86,7 +97,15 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 				) stationSelect.value = stat
 				samplingHeightInput.value = spatTemp.samplingHeight
 				externalPageInput.value = spatTemp.customLandingPage
-				varInfoForm.setValues(spatTemp.variables)
+				selsectedVars = spatTemp.variables
+				spatTemp.variables.map { varUris =>
+					datasetSpec.map { dataset => 
+						whenDone(getVariables(dataset)) { variables =>
+							varInfoForm.list = variables
+							varInfoForm.setValues(Some(varUris.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+						}
+					}
+				}
 				spatialCovSelect.handleReceivedSpatialCoverage(Some(spatTemp.spatial))
 				show()
 			case _ =>

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
@@ -38,10 +38,10 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		samplingHeight = height,
 		production = prod,
 		customLandingPage = customLanding,
-		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
+		variables = varInfo.map(_.uri.toString.split('/').last)
 	)
 
-	def varnames: Try[Seq[String]] = varInfoForm.values.map(_.getOrElse(Seq.empty).map(_.title))
+	def varnames: Try[Seq[String]] = varInfoForm.values.map(_.map(_.title))
 
 	private val titleInput = new TextInput("l3title", notifyUpdate, "elaborated product title")
 	private val descriptionInput = new DescriptionInput("l3descr", notifyUpdate)
@@ -55,14 +55,14 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 	private val varInfoForm = new L3VarInfoForm("l3varinfo-form", notifyUpdate)
 	private val externalPageInput = new UriOptInput("l3landingpage", notifyUpdate)
 	private var datasetSpec: Option[URI] = None
-	private var selsectedVars: Option[Seq[String]] = None
+	private var selsectedVars: Seq[String] = Nil
 
 	def resetForm(): Unit = {
 		Iterable(
 			titleInput, descriptionInput, timeStartInput, timeStopInput,
 			temporalResInput, externalPageInput
 		).foreach(_.reset())
-		varInfoForm.setValues(None)
+		varInfoForm.setValues(Nil)
 		spatialCovSelect.resetForm()
 	}
 
@@ -76,9 +76,8 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		case GotStationsList(stations) => stationSelect.setOptions(stations)
 		case GotVariableList(variables) =>
 			varInfoForm.list = variables
-			selsectedVars.map { variables =>
-				varInfoForm.setValues(Some(variables.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
-			}
+			varInfoForm.setValues(selsectedVars.flatMap(uri =>
+					varInfoForm.list.find(_.uri.toString.split('/').last == uri)))
 
 	}
 
@@ -98,14 +97,19 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 				samplingHeightInput.value = spatTemp.samplingHeight
 				externalPageInput.value = spatTemp.customLandingPage
 				selsectedVars = spatTemp.variables
-				spatTemp.variables.map { varUris =>
-					datasetSpec.map { dataset => 
-						whenDone(getVariables(dataset)) { variables =>
-							varInfoForm.list = variables
-							varInfoForm.setValues(Some(varUris.flatMap(uri => varInfoForm.list.find(_.uri.toString.split('/').last == uri))))
+					if (selsectedVars.nonEmpty) {
+						datasetSpec match {
+							case None => ()
+							case Some(dataset) => {
+								whenDone(getVariables(dataset)) { variables =>
+									varInfoForm.list = variables
+									varInfoForm.setValues(selsectedVars.flatMap(uri =>
+										varInfoForm.list.find(_.uri.toString.split('/').last == uri)
+									))
+								}
+							}
 						}
 					}
-				}
 				spatialCovSelect.handleReceivedSpatialCoverage(Some(spatTemp.spatial))
 				show()
 			case _ =>

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/SpatioTemporalPanel.scala
@@ -41,7 +41,7 @@ class SpatioTemporalPanel(covs: IndexedSeq[SpatialCoverage])(implicit bus: PubSu
 		variables = varInfo.map(_.map(_.uri.toString.split('/').last))
 	)
 
-	def varnames: Try[Option[Seq[String]]] = varInfoForm.values.map(_.map(_.map(_.title)))
+	def varnames: Try[Seq[String]] = varInfoForm.values.map(_.getOrElse(Seq.empty).map(_.title))
 
 	private val titleInput = new TextInput("l3title", notifyUpdate, "elaborated product title")
 	private val descriptionInput = new DescriptionInput("l3descr", notifyUpdate)

--- a/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/StationTimeSeriesPanel.scala
+++ b/uploadgui/src/main/scala/se/lu/nateko/cp/meta/upload/subforms/StationTimeSeriesPanel.scala
@@ -57,10 +57,9 @@ class StationTimeSeriesPanel(covs: IndexedSeq[SpatialCoverage]) (using bus: PubS
 
 	private val customSamplingPoint = SamplingPoint(new URI(""), 0, 0, "Custom")
 
-	getElementById[html.Button]("rmL2GeoSelection").foreach: button =>
-		button.onclick = event =>
-			event.preventDefault()
-			spatialCovSelect.unselect()
+	getElementById[html.Button]("rmL2GeoSelection").onclick = event =>
+		event.preventDefault()
+		spatialCovSelect.unselect()
 
 	def resetForm(): Unit = {
 		resetPlaceInfo()


### PR DESCRIPTION
Wrapping a `Seq` in `Option` has the same semantic meaning in almost every case I can think of, and in the cases where it does not, I think an alternative and more descriptive solution should probably be used.

The changes in this PR should be functionally equivalent to the previous version, while simplifying the logic using these data types, but I have not tested anything in practice yet, so there may of course be edge cases I have not thought of.
I have left comments at relevant places for why I believe these changes are functionally equivalent and valid, though.

Note: Based on https://github.com/ICOS-Carbon-Portal/meta/pull/341 since it touches same files.

- [ ] There are a few more DTOs with `Option[Seq[]]` that should probably also be changed as part of this PR.

**Testing TODO**
- Tests should be added in a new branch, based on `master`, verifying existing behavior. Then the tests can be merged into this one.
- Where could this change have visible impacts?:
    - When registering a new metadata package, do we still accept the same payloads? Parsing of a payload happens [here](https://github.com/ICOS-Carbon-Portal/meta/blob/master/src/main/scala/se/lu/nateko/cp/meta/routes/UploadApiRoute.scala#L96).
    - The structures in [DataObject.scala)[https://github.com/ICOS-Carbon-Portal/meta/blob/master/core/src/main/scala/se/lu/nateko/cp/meta/core/data/DataObject.scala#L1] are serialized to JSON and embedded in the source of metadata previews. That is implemented in [SchemaOrg.dataJson(object: DataObject)](https://github.com/ICOS-Carbon-Portal/meta/blob/master/src/main/scala/se/lu/nateko/cp/meta/services/metaexport/SchemaOrg.scala#L196), which can be tested directly.
    - The changes affect files in `meta/upload/subforms`. Most likely, the best way to test it is to manually check that the interface still works as expected.
- Are there existing tests, and what do they cover?
    - There does not seem to be any test covering the upload route. Adding it next to [AlternativePathRouteTest](https://github.com/ICOS-Carbon-Portal/meta/blob/master/src/test/scala/se/lu/nateko/cp/meta/test/routes/AlternativePathRouteTest.scala) would make sense.