### PR TITLE
Add Sentry SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val meta = (project in file("."))
 			"com.typesafe.akka"     %% "akka-stream"                        % akkaVersion cross CrossVersion.for3Use2_13,
 			"com.typesafe.akka"     %% "akka-slf4j"                         % akkaVersion cross CrossVersion.for3Use2_13,
 			"ch.qos.logback"         % "logback-classic"                    % "1.4.14",
+			"io.sentry"              % "sentry"                             % "8.37.1",
 			"org.eclipse.rdf4j"      % "rdf4j-repository-sail"              % rdf4jVersion,
 			"org.eclipse.rdf4j"      % "rdf4j-sail-memory"                  % rdf4jVersion,
 			"org.eclipse.rdf4j"      % "rdf4j-sail-nativerdf"               % rdf4jVersion,

--- a/example.application.conf
+++ b/example.application.conf
@@ -7,5 +7,7 @@ cpmeta {
 			password: "password"
 		}
 	}
+
+	sentry.dsn = "https://<key>@<sentry-host>/<project-id>"
 }
 

--- a/src/main/scala/se/lu/nateko/cp/meta/CpmetaConfig.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/CpmetaConfig.scala
@@ -169,6 +169,8 @@ case class RestheartConfig(baseUri: String, dbNames: Map[Envri, String]) {
 
 case class StatsClientConfig(downloadsUri: String, previews: RestheartConfig)
 
+case class SentryConfig(dsn: String)
+
 case class CpmetaConfig(
 	port: Int,
 	httpBindInterface: String,
@@ -183,7 +185,8 @@ case class CpmetaConfig(
 	core: MetaCoreConfig,
 	sparql: SparqlServerConfig,
 	citations: CitationConfig,
-	statsClient: StatsClientConfig
+	statsClient: StatsClientConfig,
+	sentry: Option[SentryConfig]
 )
 
 object ConfigLoader extends CpmetaJsonProtocol:
@@ -238,8 +241,9 @@ object ConfigLoader extends CpmetaJsonProtocol:
 	given RootJsonFormat[CitationConfig] = jsonFormat4(CitationConfig.apply)
 	given RootJsonFormat[RestheartConfig] = jsonFormat2(RestheartConfig.apply)
 	given RootJsonFormat[StatsClientConfig] = jsonFormat2(StatsClientConfig.apply)
+	given RootJsonFormat[SentryConfig] = jsonFormat1(SentryConfig.apply)
 
-	given RootJsonFormat[CpmetaConfig] = jsonFormat14(CpmetaConfig.apply)
+	given RootJsonFormat[CpmetaConfig] = jsonFormat15(CpmetaConfig.apply)
 
 	lazy val default: CpmetaConfig = appConfig.getValue("cpmeta").parseAs[CpmetaConfig]
 

--- a/src/main/scala/se/lu/nateko/cp/meta/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/Main.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.Http
 import akka.stream.Materializer
+import io.sentry.Sentry
 import se.lu.nateko.cp.cpauth.core.ConfigLoader.appConfig
 import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import se.lu.nateko.cp.meta.metaflow.MetaFlow
@@ -17,11 +18,15 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 object Main extends App with CpmetaJsonProtocol{
 
+	private def initSentry(config: CpmetaConfig): Unit =
+		config.sentry.foreach(conf => Sentry.init(conf.dsn))
+
 	given system: ActorSystem = ActorSystem("cpmeta", config = appConfig)
 	private val log = Logging.getLogger(system, this)
 	private given ExecutionContext = system.dispatcher
 
 	val config: CpmetaConfig = ConfigLoader.default
+	initSentry(config)
 	given EnvriConfigs = config.core.envriConfigs
 	val metaFactory = new MetaDbFactory
 
@@ -54,13 +59,15 @@ object Main extends App with CpmetaJsonProtocol{
 		//_ = log.info("SPARQL magic index initialized, starting the HTTP server...");
 		binding <- Http().newServerAt(config.httpBindInterface, config.port).bind(route)
 	) yield {
-		sys.addShutdownHook{
+		sys.addShutdownHook {
 			metaflow.cancel()
-			try
+			try {
 				Await.result(binding.unbind(), 10.seconds)
-			finally
+			} finally {
 				db.close()
+				Sentry.close()
 				println("Metadata db has been shut down")
+			}
 
 			println("meta service shutdown successful")
 		}
@@ -68,6 +75,8 @@ object Main extends App with CpmetaJsonProtocol{
 	}
 
 	startup.failed.foreach{err =>
+		Sentry.captureException(err)
+		Sentry.flush(5000)
 		log.error(err, "Could not start meta service")
 		system.terminate()
 	}

--- a/src/main/scala/se/lu/nateko/cp/meta/Main.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/Main.scala
@@ -18,9 +18,6 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 object Main extends App with CpmetaJsonProtocol{
 
-	private def initSentry(config: CpmetaConfig): Unit =
-		config.sentry.foreach(conf => Sentry.init(conf.dsn))
-
 	given system: ActorSystem = ActorSystem("cpmeta", config = appConfig)
 	private val log = Logging.getLogger(system, this)
 	private given ExecutionContext = system.dispatcher
@@ -81,3 +78,9 @@ object Main extends App with CpmetaJsonProtocol{
 		system.terminate()
 	}
 }
+
+private def initSentry(config: CpmetaConfig): Unit =
+	config.sentry match {
+		case Some(conf) => Sentry.init(conf.dsn)
+		case None => ()
+	}

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/MainRoute.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/MainRoute.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.*
 import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.{ExceptionHandler, Route}
 import akka.stream.Materializer
+import io.sentry.Sentry
 import se.lu.nateko.cp.meta.api.SparqlQuery
 import se.lu.nateko.cp.meta.core.data.{EnvriConfig, EnvriConfigs}
 import se.lu.nateko.cp.meta.metaflow.MetaFlow
@@ -21,6 +22,7 @@ object MainRoute {
 
 	def exceptionHandler(using envriConfigs: EnvriConfigs) = ExceptionHandler{
 		case ex =>
+			Sentry.captureException(ex)
 			val extractEnvri = AuthenticationRouting.extractEnvriDirective
 			extractEnvri { implicit envri =>
 				given EnvriConfig = envriConfigs(envri)


### PR DESCRIPTION
This change adds the Sentry SDK and initializes it with the default configuration and uncaught route exceptions.

The Sentry DSN can be specified by adding the following line to `application.conf`.
```
cpmeta.sentry.dsn = "https://<key>@<sentry-host>/<project-id>"
```
