### PR TITLE
Add a SPARQL link for types in the editor

### DIFF
--- a/src/main/js/metaentry/AppLayout.jsx
+++ b/src/main/js/metaentry/AppLayout.jsx
@@ -1,6 +1,6 @@
 var actions = Reflux.createActions([
-	"chooseMetaType",
-	"chooseIndividual",
+	"selectMetaType",
+	"selectIndividual",
 	"requestUpdate",
 	"checkUriOrSuffix",
 	"createIndividual",
@@ -9,13 +9,13 @@ var actions = Reflux.createActions([
 
 var Backend = require('./backend.js');
 
-var TypesStore = require('./stores/TypesStoreFactory.js')(Backend, actions.chooseMetaType, actions.checkUriOrSuffix);
-var IndividualsStore = require('./stores/IndividualsStoreFactory.js')(Backend, actions.chooseMetaType, actions.chooseIndividual, actions.createIndividual, actions.removeIndividual);
-var EditStore = require('./stores/EditStoreFactory.js')(Backend, actions.chooseIndividual, actions.requestUpdate);
+var TypesStore = require('./stores/TypesStoreFactory.js')(Backend, actions.selectMetaType, actions.checkUriOrSuffix);
+var IndividualsStore = require('./stores/IndividualsStoreFactory.js')(Backend, actions.selectMetaType, actions.selectIndividual, actions.createIndividual, actions.removeIndividual);
+var EditStore = require('./stores/EditStoreFactory.js')(Backend, actions.selectIndividual, actions.requestUpdate);
 
-var TypesList = require('./views/TypesListFactory.jsx')(TypesStore, actions.chooseMetaType);
+var TypesList = require('./views/TypesListFactory.jsx')(TypesStore, actions.selectMetaType);
 var IndividualAdder = require('./views/IndividualAdderFactory.jsx')(TypesStore, actions.checkUriOrSuffix, actions.createIndividual);
-var IndividualsList = require('./views/IndividualsListFactory.jsx')(IndividualsStore, actions.chooseIndividual, actions.removeIndividual, IndividualAdder);
+var IndividualsList = require('./views/IndividualsListFactory.jsx')(IndividualsStore, actions.selectIndividual, actions.removeIndividual, IndividualAdder);
 var EditView = require('./views/EditViewFactory.jsx')(EditStore, actions.requestUpdate);
 
 module.exports = React.createClass({
@@ -28,4 +28,3 @@ module.exports = React.createClass({
 		</div>;
 	}
 });
-

--- a/src/main/js/metaentry/backend.js
+++ b/src/main/js/metaentry/backend.js
@@ -12,6 +12,13 @@ export default {
 		return ajax.getJson(url);
 	},
 
+	getIndividualsSparql(classUri){
+		var url = 'getIndividualsSparql?classUri=' + encodeURIComponent(classUri);
+		return ajax.getJson(url).then(function(response){
+			return response.query;
+		});
+	},
+
 	getIndividual(uri){
 		var url = 'getIndividual?uri=' + encodeURIComponent(uri);
 		return ajax.getJson(url);
@@ -48,4 +55,3 @@ export default {
 		return ajax.getJson(url);
 	}
 };
-

--- a/src/main/js/metaentry/stores/EditStoreFactory.js
+++ b/src/main/js/metaentry/stores/EditStoreFactory.js
@@ -1,6 +1,6 @@
 var Individual = require('../models/Individual.js');
 
-module.exports = function(Backend, chooseIndividAction, requestUpdateAction){
+module.exports = function(Backend, selectIndividAction, requestUpdateAction){
 	return Reflux.createStore({
 
 		getInitialState: function(){
@@ -20,7 +20,7 @@ module.exports = function(Backend, chooseIndividAction, requestUpdateAction){
 		},
 
 		init: function(){
-			this.listenTo(chooseIndividAction, this.handleIndividChoice);
+			this.listenTo(selectIndividAction, this.handleIndividChoice);
 			this.listenTo(requestUpdateAction, this.handleUpdateRequest);
 		},
 
@@ -164,4 +164,3 @@ module.exports = function(Backend, chooseIndividAction, requestUpdateAction){
 		}
 	});
 };
-

--- a/src/main/js/metaentry/stores/IndividualsStoreFactory.js
+++ b/src/main/js/metaentry/stores/IndividualsStoreFactory.js
@@ -1,4 +1,4 @@
-module.exports = function(Backend, chooseTypeAction, chooseIndividAction, createIndividualAction, deleteIndividualAction){
+module.exports = function(Backend, selectTypeAction, selectIndividAction, createIndividualAction, deleteIndividualAction){
 	return Reflux.createStore({
 
 		publishState: function(){
@@ -12,49 +12,66 @@ module.exports = function(Backend, chooseTypeAction, chooseIndividAction, create
 		init: function(){
 			this.state = {
 				individuals: [],
+				individualsSparql: null,
+				selectedType: null,
 				addingInstance: false, //needed by the IndividualsList view to hide the IndividualAdder when refreshing
-				chosen: null
+				selectedIndividual: null
 			};
-			this.listenTo(chooseTypeAction, this.fetchIndividuals);
-			this.listenTo(chooseIndividAction, this.updateChosenIndivid);
+			this.listenTo(selectTypeAction, this.fetchIndividuals);
+			this.listenTo(selectIndividAction, this.updateSelectedIndivid);
 			this.listenTo(createIndividualAction, this.createIndividual);
 			this.listenTo(deleteIndividualAction, this.deleteIndividual);
 		},
 
-		fetchIndividuals: function(chosenType){
+		fetchIndividuals: function(selectedType){
 
 			var self = this;
-			self.chosenType = chosenType;
+			self.selectedType = selectedType;
+			self.state.selectedType = selectedType;
+			self.publishState();
 
-			Backend.listIndividuals(chosenType).then(
+			Backend.listIndividuals(selectedType).then(
 				function(individuals){
 
-					if(chosenType !== self.chosenType) return;
+					if(selectedType !== self.selectedType) return;
 
 					self.state.individuals = individuals;
 					self.publishState();
 				},
 				function(err){
-					self.chosenType = undefined;
+					self.selectedType = undefined;
+					console.log(err);
+				}
+			);
+
+			Backend.getIndividualsSparql(selectedType).then(
+				function(individualsSparql){
+
+					if(selectedType !== self.selectedType) return;
+
+					self.state.individualsSparql = individualsSparql;
+					self.publishState();
+				},
+				function(err){
 					console.log(err);
 				}
 			);
 		},
 
-		updateChosenIndivid: function(chosenIndivid){
-			this.state.chosen = chosenIndivid;
+		updateSelectedIndivid: function(selectedIndivid){
+			this.state.selectedIndividual = selectedIndivid;
 			this.publishState();
 		},
 
 		createIndividual: function(newIndReq){
 			var self = this;
-			if(this.chosenType !== newIndReq.type) return;
+			if(this.selectedType !== newIndReq.type) return;
 
 			Backend.createIndividual(newIndReq.uri, newIndReq.type).then(
 				function(){
 					//TODO Revise the next two lines and the related data flow
 					self.fetchIndividuals(newIndReq.type);
-					chooseIndividAction(newIndReq.uri); //will trigger both this store and the EditStore
+					selectIndividAction(newIndReq.uri); //will trigger both this store and the EditStore
 				},
 				function(err){console.log(err);}
 			);
@@ -68,9 +85,9 @@ module.exports = function(Backend, chooseTypeAction, chooseIndividAction, create
 						return ind.uri !== indUri;
 					});
 					//TODO Revise the next lines and the related data flow
-					if(self.state.chosen === indUri) {
-						self.state.chosen == null;
-						chooseIndividAction(null);
+					if(self.state.selectedIndividual === indUri) {
+						self.state.selectedIndividual == null;
+						selectIndividAction(null);
 					} else self.publishState();
 					
 				},
@@ -80,4 +97,3 @@ module.exports = function(Backend, chooseTypeAction, chooseIndividAction, create
 
 	});
 }
-

--- a/src/main/js/metaentry/stores/IndividualsStoreFactory.js
+++ b/src/main/js/metaentry/stores/IndividualsStoreFactory.js
@@ -33,6 +33,7 @@ module.exports = function(Backend, selectTypeAction, selectIndividAction, create
 			Backend.listIndividuals(selectedType).then(
 				function(individuals){
 
+					// Ignore stale async responses after the user switched type.
 					if(selectedType !== self.selectedType) return;
 
 					self.state.individuals = individuals;
@@ -47,6 +48,7 @@ module.exports = function(Backend, selectTypeAction, selectIndividAction, create
 			Backend.getIndividualsSparql(selectedType).then(
 				function(individualsSparql){
 
+					// Ignore stale async responses after the user switched type.
 					if(selectedType !== self.selectedType) return;
 
 					self.state.individualsSparql = individualsSparql;

--- a/src/main/js/metaentry/stores/TypesStoreFactory.js
+++ b/src/main/js/metaentry/stores/TypesStoreFactory.js
@@ -1,4 +1,4 @@
-export default function(Backend, chooseTypeAction, checkUriOrSuffixAction){
+export default function(Backend, selectTypeAction, checkUriOrSuffixAction){
 
 	const uriCheck = _.debounce(
 		function(uri, onSuccess){
@@ -19,15 +19,15 @@ export default function(Backend, chooseTypeAction, checkUriOrSuffixAction){
 		getInitialState: function(){
 			return {
 				types: [],
-				chosen: null,
-				chosenIdx: -1,
+				selected: null,
+				selectedIdx: -1,
 				candidateUri: null,
 				uriAvailable: false
 			};
 		},
 
 		init: function(){
-			this.listenTo(chooseTypeAction, this.setChosenType);
+			this.listenTo(selectTypeAction, this.setSelectedType);
 			this.listenTo(checkUriOrSuffixAction, this.checkUriOrSuffix);
 			this.state = this.getInitialState();
 			var self = this;
@@ -41,16 +41,16 @@ export default function(Backend, chooseTypeAction, checkUriOrSuffixAction){
 			);
 		},
 
-		setChosenType: function(chosenType){
+		setSelectedType: function(selectedType){
 
-			if(this.state.chosen != chosenType){
+			if(this.state.selected != selectedType){
 
-				const chosenIdx = _.findIndex(this.state.types, theType => (theType.uri == chosenType));
+				const selectedIdx = _.findIndex(this.state.types, theType => (theType.uri == selectedType));
 
 				this.state = _.extend(this.getInitialState(), {
 					types: this.state.types,
-					chosen: chosenType,
-					chosenIdx
+					selected: selectedType,
+					selectedIdx
 				});
 
 				this.publishState();
@@ -59,7 +59,7 @@ export default function(Backend, chooseTypeAction, checkUriOrSuffixAction){
 		},
 
 		checkUriOrSuffix: function(uriOrSuffix){
-			if(!uriOrSuffix || this.state.chosenIdx < 0 || this.state.chosenIdx >= this.state.types.length){
+			if(!uriOrSuffix || this.state.selectedIdx < 0 || this.state.selectedIdx >= this.state.types.length){
 				_.extend(this.state, {uriAvailable: false, candidateUri: null})
 				this.publishState()
 				return
@@ -69,7 +69,7 @@ export default function(Backend, chooseTypeAction, checkUriOrSuffixAction){
 			var uri = uriOrSuffix.match(regex)
 
 			if(!uri || uri.length == 0){
-				var uriBase = this.state.types[this.state.chosenIdx].newInstanceBaseUri;
+				var uriBase = this.state.types[this.state.selectedIdx].newInstanceBaseUri;
 				var uri = uriBase + encodeURIComponent(uriOrSuffix.trim().replace(/ /g, '_'))
 			}
 

--- a/src/main/js/metaentry/views/IndividualAdderFactory.jsx
+++ b/src/main/js/metaentry/views/IndividualAdderFactory.jsx
@@ -31,7 +31,7 @@ module.exports = function(typesStore, checkUriOrSuffixAction, createIndividualAc
 		clickHandler: function(){
 			if(this.state.uriAvailable) createIndividualAction({
 				uri: this.state.candidateUri,
-				type: this.state.chosen
+				type: this.state.selected
 			})
 			this.cancelAddition()
 		},
@@ -53,4 +53,3 @@ module.exports = function(typesStore, checkUriOrSuffixAction, createIndividualAc
 	});
 
 };
-

--- a/src/main/js/metaentry/views/IndividualListItem.jsx
+++ b/src/main/js/metaentry/views/IndividualListItem.jsx
@@ -8,7 +8,7 @@ module.exports = React.createClass({
 	render: function(){
 
 		var ind = this.props.individual;
-		var itemClasses = "list-group-item" + (ind.isChosen ? " list-group-item-info" : "");
+		var itemClasses = "list-group-item" + (ind.isSelected ? " list-group-item-info" : "");
 
 		return <li className={itemClasses} title={ind.displayName} onClick={ind.clickHandler} style={{padding: '0px'}} role="menuitem">
 

--- a/src/main/js/metaentry/views/IndividualsListFactory.jsx
+++ b/src/main/js/metaentry/views/IndividualsListFactory.jsx
@@ -2,7 +2,25 @@ var IndividualListItem = require('./IndividualListItem.jsx');
 var Widget = require('./widgets/Widget.jsx');
 var ScreenHeightColumn = require('./ScreenHeightColumn.jsx');
 
-module.exports = function(individualsStore, chooseAction, removeAction, IndividualAdder){
+function submitSparqlQuery(query){
+	var form = document.createElement('form');
+	form.method = 'POST';
+	form.action = '/sparqlclient/';
+	form.target = '_blank';
+	form.style.display = 'none';
+
+	var queryInput = document.createElement('input');
+	queryInput.type = 'hidden';
+	queryInput.name = 'query';
+	queryInput.value = query;
+	form.appendChild(queryInput);
+
+	document.body.appendChild(form);
+	form.submit();
+	document.body.removeChild(form);
+}
+
+module.exports = function(individualsStore, selectAction, removeAction, IndividualAdder){
 
 	return React.createClass({
 
@@ -11,8 +29,21 @@ module.exports = function(individualsStore, chooseAction, removeAction, Individu
 		render: function(){
 			var self = this;
 
+			if(!this.state.selectedType) return null;
+
 			var buttons = [{
+				icon: 'share-square',
+				label: 'View SPARQL query',
+				noLeftMargin: true,
+				isDisabled: !this.state.individualsSparql,
+				clickHandler: function(){
+					if(!self.state.individualsSparql) return;
+					submitSparqlQuery(self.state.individualsSparql);
+				}
+			}, {
 				icon: 'plus',
+				label: 'Add entry',
+				btnVariant: 'btn-primary',
 				isDisabled: this.state.addingInstance,
 				clickHandler: function(){
 					self.setState({addingInstance: true});
@@ -21,16 +52,17 @@ module.exports = function(individualsStore, chooseAction, removeAction, Individu
 
 			var individuals = _.chain(this.state.individuals)
 				.map(function(individual){
+					var isSelected = (individual.uri === self.state.selectedIndividual);
 					return _.extend({}, individual, {
-						clickHandler: _.partial(chooseAction, individual.uri),
+						clickHandler: _.partial(selectAction, individual.uri),
 						deletionHandler: _.partial(removeAction, individual.uri),
-						isChosen: (individual.uri === self.state.chosen)
+						isSelected: isSelected
 					});
 				})
 				.sortBy("displayName")
 				.value();
 
-			return <Widget widgetTitle="Entries" buttons={buttons}>
+			return <Widget widgetTitle="Entries" buttons={buttons} buttonsInBody={true}>
 
 				{this.state.addingInstance ? <IndividualAdder cancelHandler={this.hideAdder}/> : null}
 

--- a/src/main/js/metaentry/views/TypesListFactory.jsx
+++ b/src/main/js/metaentry/views/TypesListFactory.jsx
@@ -2,7 +2,7 @@ var capped = require('../utils.js').ensureLength(30);
 var Widget = require('./widgets/Widget.jsx');
 var ScreenHeightColumn = require('./ScreenHeightColumn.jsx');
 
-module.exports = function(typesStore, chooseTypeAction){
+module.exports = function(typesStore, selectTypeAction){
 
 	return React.createClass({
 
@@ -15,16 +15,16 @@ module.exports = function(typesStore, chooseTypeAction){
 				<ScreenHeightColumn>
 					<div className="list-group" role="menu">{
 
-						this.state.types.map(function(theType){
+					this.state.types.map(function(theType){
 
-							var clickHandler = _.partial(chooseTypeAction, theType.uri);
-							var isChosen = (theType.uri == self.state.chosen);
-							var fullName = theType.displayName;
+						var clickHandler = _.partial(selectTypeAction, theType.uri);
+						var isSelected = (theType.uri == self.state.selected);
+						var fullName = theType.displayName;
 
-							return <li
-								className={"cp-lnk list-group-item" + (isChosen ? " list-group-item-info" : "")}
-								key={theType.uri} title={fullName} onClick={clickHandler} role="menuitem">
-								{capped(fullName)}
+						return <li
+							className={"cp-lnk list-group-item" + (isSelected ? " list-group-item-info" : "")}
+							key={theType.uri} title={fullName} onClick={clickHandler} role="menuitem">
+							{capped(fullName)}
 							</li>;
 						})
 

--- a/src/main/js/metaentry/views/widgets/ObjectValueDropdown.jsx
+++ b/src/main/js/metaentry/views/widgets/ObjectValueDropdown.jsx
@@ -10,7 +10,7 @@ export default React.createClass({
 
 		const instruction = _.isEmpty(rangeValues)
 			? "Enter URL to be the new value:"
-			: "Double-click and choose the new value (type to search), or enter a URL:";
+			: "Double-click and select the new value (type to search), or enter a URL:";
 
 		const saveDisabled = this.state && !this.state.valid;
 		const saveButtClass = "btn btn-" + (saveDisabled ? "danger" : "primary");
@@ -59,4 +59,3 @@ export default React.createClass({
 	},
 
 });
-

--- a/src/main/js/metaentry/views/widgets/Widget.jsx
+++ b/src/main/js/metaentry/views/widgets/Widget.jsx
@@ -2,31 +2,34 @@ var WidgetButton = require('./WidgetButton.jsx');
 
 module.exports = React.createClass({
 
-	render: function(){
+		render: function(){
 
-		var background = this.props.widgetType ? " bg-" + this.props.widgetType : "";
-		var cssClasses = "card-header" + background;
-		var buttons = this.props.buttons || [];
+			var background = this.props.widgetType ? " bg-" + this.props.widgetType : "";
+			var cssClasses = "card-header" + background;
+			var buttons = this.props.buttons || [];
+			var showButtonsInHeader = !this.props.buttonsInBody;
 
-		return <div className="card mb-3">
+			var renderedButtons = _.map(buttons, function(buttProps, i){
+				var props = _.extend({}, buttProps, {key: "propButton_" + i});
+				return <WidgetButton {...props}/>;
+			});
 
-			<div className={cssClasses} title={this.props.headerTitle}>
+			return <div className="card mb-3">
 
-				<h3 style={{ display: "inline" }} className="fs-6">{this.props.widgetTitle}</h3>
+				<div className={cssClasses} title={this.props.headerTitle}>
+					<div className="d-flex justify-content-between align-items-center">
+						<h3 className="fs-6" style={{marginBottom: 0}}>{this.props.widgetTitle}</h3>
+						{showButtonsInHeader ? <div>{renderedButtons}</div> : null}
+					</div>
 
-				<div style={{display: "inline", float: "right"}}>{
-					_.map(buttons, function(buttProps, i){
-						var props = _.extend({}, buttProps, {key: "propButton_" + i});
-						return <WidgetButton {...props}/>;
-					})
-				}</div>
+				</div>
 
-			</div>
+				<div className="card-body">
+					{this.props.buttonsInBody ? <div className="d-flex flex-column flex-xl-row flex-xl-wrap justify-content-between gap-2 mb-2">{renderedButtons}</div> : null}
+					{this.props.children}
+				</div>
 
-			<div className="card-body">{this.props.children}</div>
-
-		</div>;
-	}
+			</div>;
+		}
 
 });
-

--- a/src/main/js/metaentry/views/widgets/WidgetButton.jsx
+++ b/src/main/js/metaentry/views/widgets/WidgetButton.jsx
@@ -32,8 +32,30 @@ module.exports = React.createClass({
 
 	render: function(){
 		var state = this.state;
+		var btnVariant = state.btnVariant || "btn-outline-secondary";
+		var marginClass = state.noLeftMargin ? "" : " ms-xl-2";
+		var buttonClasses = "btn btn-sm text-nowrap flex-shrink-0" + marginClass + " " + btnVariant;
 
-		if(state.isDisabled) return null;
+		if(state.label){
+			var icon = state.icon ? <span className={"fas fa-" + state.icon + " me-1"}></span> : null;
+			return <button
+				type="button"
+				className={buttonClasses}
+				onClick={state.clickHandler}
+				disabled={!!state.isDisabled}
+			>{icon}{state.label}</button>;
+		}
+
+		if(state.asButton){
+			return <button
+				type="button"
+				className={buttonClasses}
+				onClick={state.clickHandler}
+				disabled={!!state.isDisabled}
+			><span className={"fas fa-" + state.icon}></span></button>;
+		}
+
+			if(state.isDisabled) return null;
 
 		var cssClasses = "fas fa-" + state.icon;
 		return <span className={cssClasses} onClick={state.clickHandler} role="button"></span>;

--- a/src/main/js/metaentry/views/widgets/WidgetButton.jsx
+++ b/src/main/js/metaentry/views/widgets/WidgetButton.jsx
@@ -33,8 +33,7 @@ module.exports = React.createClass({
 	render: function(){
 		var state = this.state;
 		var btnVariant = state.btnVariant || "btn-outline-secondary";
-		var marginClass = state.noLeftMargin ? "" : " ms-xl-2";
-		var buttonClasses = "btn btn-sm text-nowrap flex-shrink-0" + marginClass + " " + btnVariant;
+		var buttonClasses = "btn btn-sm text-nowrap flex-shrink-0 " + btnVariant;
 
 		if(state.label){
 			var icon = state.icon ? <span className={"fas fa-" + state.icon + " me-1"}></span> : null;

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala
@@ -44,6 +44,85 @@ class InstOnto (instServer: InstanceServer, val onto: Onto):
 		val labeler = onto.getLabelerForClassIndividuals(classUri)
 		getPropValueHolders(RDF.TYPE, classUri.toRdf).map(labeler.getInfo)
 
+	def getIndividualsSparql(classUri: URI, subjectPrefix: Option[String]): String =
+		val classInfo = onto.getClassInfo(classUri)
+		val propUris = (
+			classInfo.properties.map {
+				case p: DataPropertyDto => p.resource.uri
+				case p: ObjectPropertyDto => p.resource.uri
+			} ++ Seq(RDFS.LABEL.toJava, RDFS.COMMENT.toJava)
+		).distinct.filterNot(_ == RDF.TYPE.toJava)
+
+		val usedNames = scala.collection.mutable.Set.empty[String]
+		def uniqueVarName(propUri: URI): String =
+			val base = sparqlVarBase(propUri)
+			val name = Iterator.from(1)
+				.map(i => if i == 1 then base else s"$base$i")
+				.find(name => !usedNames.contains(name))
+				.get
+			usedNames += name
+			name
+
+		val bindings = propUris.map(uri => (uri, uniqueVarName(uri)))
+		val selectVars = ("?s" +: bindings.map{case (_, name) => s"?$name"}).mkString(" ")
+		val optionalPatterns = bindings
+			.map{case (uri, name) => s"\tOPTIONAL { ?s ${sparqlPredicate(uri)} ?$name . }"}
+			.mkString("\n")
+		val subjectPrefixFilter = subjectPrefix
+			.map(prefix => s"\tFILTER(STRSTARTS(STR(?s), ${sparqlStringLiteral(prefix)}))")
+			.getOrElse("")
+
+		s"""PREFIX cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
+		|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+		|PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+		|
+		|SELECT $selectVars
+		|WHERE {
+		|	?s rdf:type <${classUri.toString}> .
+		|$subjectPrefixFilter
+		|$optionalPatterns
+		|}
+		|ORDER BY ?s""".stripMargin
+
+	private def sparqlPredicate(uri: URI): String =
+		val cpmetaPrefix = "http://meta.icos-cp.eu/ontologies/cpmeta/"
+		val rdfsPrefix = "http://www.w3.org/2000/01/rdf-schema#"
+		val str = uri.toString
+		if str.startsWith(cpmetaPrefix) then
+			val suffix = str.substring(cpmetaPrefix.length)
+			if suffix.matches("[A-Za-z_][A-Za-z0-9_\\.-]*") then s"cpmeta:$suffix"
+			else s"<$str>"
+		else if str.startsWith(rdfsPrefix) then
+			val suffix = str.substring(rdfsPrefix.length)
+			if suffix.matches("[A-Za-z_][A-Za-z0-9_\\.-]*") then s"rdfs:$suffix"
+			else s"<$str>"
+		else s"<$str>"
+
+	private def sparqlVarBase(propUri: URI): String =
+		if propUri == RDFS.LABEL.toJava then "label"
+		else if propUri == RDFS.COMMENT.toJava then "comment"
+		else
+			val local = Option(propUri.getFragment)
+				.orElse(Option(propUri.getPath).flatMap(_.split('/').lastOption))
+				.getOrElse("value")
+			val withoutHasPrefix =
+				if local.startsWith("has") && local.length > 3 && local.charAt(3).isUpper
+				then local.substring(3)
+				else local
+			val lowerCamel = withoutHasPrefix.headOption
+				.map(ch => ch.toLower.toString + withoutHasPrefix.substring(1))
+				.getOrElse("value")
+			val clean = lowerCamel
+				.replaceAll("[^A-Za-z0-9_]", "_")
+				.replaceAll("^[^A-Za-z_]+", "")
+			if clean.isEmpty then "value" else clean
+
+	private def sparqlStringLiteral(str: String): String =
+		val escaped = str
+			.replace("\\", "\\\\")
+			.replace("\"", "\\\"")
+		s"\"$escaped\""
+
 
 	def getRangeValues(individClassUri: URI, propUri: URI): Seq[ResourceDto] = {
 		assert(individClassUri != null)//just to silence the not-used warning;

--- a/src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala
@@ -11,6 +11,7 @@ import se.lu.nateko.cp.meta.instanceserver.{InstanceServer, RdfUpdate, Statement
 import se.lu.nateko.cp.meta.utils.rdf4j.*
 
 import java.net.URI
+import scala.collection.mutable
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Try}
 
@@ -44,37 +45,29 @@ class InstOnto (instServer: InstanceServer, val onto: Onto):
 		val labeler = onto.getLabelerForClassIndividuals(classUri)
 		getPropValueHolders(RDF.TYPE, classUri.toRdf).map(labeler.getInfo)
 
-	def getIndividualsSparql(classUri: URI, subjectPrefix: Option[String]): String =
+	def getIndividualsSparql(classUri: URI, subjectPrefix: Option[URI]): String =
 		val classInfo = onto.getClassInfo(classUri)
 		val propUris = (
 			classInfo.properties.map {
 				case p: DataPropertyDto => p.resource.uri
 				case p: ObjectPropertyDto => p.resource.uri
-			} ++ Seq(RDFS.LABEL.toJava, RDFS.COMMENT.toJava)
+			} ++ Seq(RDFS.LABEL.toJava, RDFS.COMMENT.toJava, RDFS.SEEALSO.toJava)
 		).distinct.filterNot(_ == RDF.TYPE.toJava)
 
-		val usedNames = scala.collection.mutable.Set.empty[String]
-		def uniqueVarName(propUri: URI): String =
-			val base = sparqlVarBase(propUri)
-			val name = Iterator.from(1)
-				.map(i => if i == 1 then base else s"$base$i")
-				.find(name => !usedNames.contains(name))
-				.get
-			usedNames += name
-			name
+		val nextVarName = varNameGenerator()
 
-		val bindings = propUris.map(uri => (uri, uniqueVarName(uri)))
+		val bindings = propUris.map(uri => (uri, nextVarName(sparqlVarBase(uri))))
 		val selectVars = ("?s" +: bindings.map{case (_, name) => s"?$name"}).mkString(" ")
 		val optionalPatterns = bindings
 			.map{case (uri, name) => s"\tOPTIONAL { ?s ${sparqlPredicate(uri)} ?$name . }"}
 			.mkString("\n")
 		val subjectPrefixFilter = subjectPrefix
-			.map(prefix => s"\tFILTER(STRSTARTS(STR(?s), ${sparqlStringLiteral(prefix)}))")
+			.map(prefix => s"""\tFILTER(STRSTARTS(STR(?s), "${prefix.toString}"))""")
 			.getOrElse("")
 
-		s"""PREFIX cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
-		|PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-		|PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+		s"""PREFIX cpmeta: <${OntoConstants.CpmetaPrefix}>
+		|PREFIX rdf: <${RDF.NAMESPACE}>
+		|PREFIX rdfs: <${RDFS.NAMESPACE}>
 		|
 		|SELECT $selectVars
 		|WHERE {
@@ -85,44 +78,40 @@ class InstOnto (instServer: InstanceServer, val onto: Onto):
 		|ORDER BY ?s""".stripMargin
 
 	private def sparqlPredicate(uri: URI): String =
-		val cpmetaPrefix = "http://meta.icos-cp.eu/ontologies/cpmeta/"
-		val rdfsPrefix = "http://www.w3.org/2000/01/rdf-schema#"
 		val str = uri.toString
-		if str.startsWith(cpmetaPrefix) then
-			val suffix = str.substring(cpmetaPrefix.length)
-			if suffix.matches("[A-Za-z_][A-Za-z0-9_\\.-]*") then s"cpmeta:$suffix"
-			else s"<$str>"
-		else if str.startsWith(rdfsPrefix) then
-			val suffix = str.substring(rdfsPrefix.length)
-			if suffix.matches("[A-Za-z_][A-Za-z0-9_\\.-]*") then s"rdfs:$suffix"
-			else s"<$str>"
-		else s"<$str>"
+		val prefixes: Map[String, String] = Map(
+			"cpmeta" -> OntoConstants.CpmetaPrefix,
+			"rdfs" -> RDFS.NAMESPACE
+		)
+		prefixes.collectFirst{
+			case (prefix, namespace) if str.startsWith(namespace) =>
+				val suffix = str.substring(namespace.length)
+				if suffix.matches("[A-Za-z_][A-Za-z0-9_\\.-]*") then s"$prefix:$suffix"
+				else s"<$str>"
+		}.getOrElse(s"<$str>")
+
+	private def varNameGenerator(): String => String =
+		val counters = mutable.Map.empty[String, Int]
+		base =>
+			val next = counters.getOrElse(base, 0) + 1
+			counters.update(base, next)
+			if next == 1 then base else s"$base$next"
 
 	private def sparqlVarBase(propUri: URI): String =
-		if propUri == RDFS.LABEL.toJava then "label"
-		else if propUri == RDFS.COMMENT.toJava then "comment"
-		else
-			val local = Option(propUri.getFragment)
-				.orElse(Option(propUri.getPath).flatMap(_.split('/').lastOption))
-				.getOrElse("value")
-			val withoutHasPrefix =
-				if local.startsWith("has") && local.length > 3 && local.charAt(3).isUpper
-				then local.substring(3)
-				else local
-			val lowerCamel = withoutHasPrefix.headOption
-				.map(ch => ch.toLower.toString + withoutHasPrefix.substring(1))
-				.getOrElse("value")
-			val clean = lowerCamel
-				.replaceAll("[^A-Za-z0-9_]", "_")
-				.replaceAll("^[^A-Za-z_]+", "")
-			if clean.isEmpty then "value" else clean
-
-	private def sparqlStringLiteral(str: String): String =
-		val escaped = str
-			.replace("\\", "\\\\")
-			.replace("\"", "\\\"")
-		s"\"$escaped\""
-
+		val local = Option(propUri.getFragment)
+			.orElse(Option(propUri.getPath).flatMap(_.split('/').lastOption))
+			.getOrElse("value")
+		val withoutHasPrefix =
+			if local.startsWith("has") && local.length > 3 && local.charAt(3).isUpper
+			then local.substring(3)
+			else local
+		val lowerCamel = withoutHasPrefix.headOption
+			.map(ch => ch.toLower.toString + withoutHasPrefix.substring(1))
+			.getOrElse("value")
+		val clean = lowerCamel
+			.replaceAll("[^A-Za-z0-9_]", "_")
+			.replaceAll("^[^A-Za-z_]+", "")
+		if clean.isEmpty then "value" else clean
 
 	def getRangeValues(individClassUri: URI, propUri: URI): Seq[ResourceDto] = {
 		assert(individClassUri != null)//just to silence the not-used warning;

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/MetadataEntryRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/MetadataEntryRouting.scala
@@ -5,12 +5,13 @@ import akka.http.scaladsl.server.Directives.*
 import akka.http.scaladsl.server.Route
 import se.lu.nateko.cp.meta.onto.InstOnto
 import se.lu.nateko.cp.meta.{CpmetaJsonProtocol, InstOntoServerConfig, ReplaceDto, UpdateDto}
+import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import spray.json.*
 
 import java.net.URI
 import scala.language.implicitConversions
 
-class MetadataEntryRouting(authRouting: AuthenticationRouting) extends CpmetaJsonProtocol{
+class MetadataEntryRouting(authRouting: AuthenticationRouting)(using envriConfigs: EnvriConfigs) extends CpmetaJsonProtocol{
 
 	def entryRoute(instOntos: Map[String, InstOnto], ontoConfs: Map[String, InstOntoServerConfig]): Route = {
 		val ontoInfos = ontoConfs.map{
@@ -31,6 +32,7 @@ class MetadataEntryRouting(authRouting: AuthenticationRouting) extends CpmetaJso
 
 	def singleOntoRoute(instOnto: InstOnto, authorizedUsers: Seq[String]): Route = {
 		val onto = instOnto.onto
+		val extractEnvri = AuthenticationRouting.extractEnvriDirective
 		get{
 			pathSuffix("getExposedClasses"){
 				complete(onto.getExposedClasses.map(_.withFallbackBaseUri(instOnto.getWriteContext)))
@@ -38,6 +40,14 @@ class MetadataEntryRouting(authRouting: AuthenticationRouting) extends CpmetaJso
 			pathSuffix("listIndividuals"){
 				parameter("classUri"){ uriStr =>
 					complete(instOnto.getIndividuals(new URI(uriStr)))
+				}
+			} ~
+			pathSuffix("getIndividualsSparql"){
+				extractEnvri{ envri =>
+					parameter("classUri"){ uriStr =>
+						val subjectPrefix = Some(envriConfigs(envri).metaItemPrefix.toString)
+						complete(JsObject("query" -> JsString(instOnto.getIndividualsSparql(new URI(uriStr), subjectPrefix))))
+					}
 				}
 			} ~
 			pathSuffix("getIndividual"){

--- a/src/main/scala/se/lu/nateko/cp/meta/routes/MetadataEntryRouting.scala
+++ b/src/main/scala/se/lu/nateko/cp/meta/routes/MetadataEntryRouting.scala
@@ -45,7 +45,7 @@ class MetadataEntryRouting(authRouting: AuthenticationRouting)(using envriConfig
 			pathSuffix("getIndividualsSparql"){
 				extractEnvri{ envri =>
 					parameter("classUri"){ uriStr =>
-						val subjectPrefix = Some(envriConfigs(envri).metaItemPrefix.toString)
+						val subjectPrefix = Some(envriConfigs(envri).metaItemPrefix)
 						complete(JsObject("query" -> JsString(instOnto.getIndividualsSparql(new URI(uriStr), subjectPrefix))))
 					}
 				}

--- a/src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala
@@ -1,5 +1,6 @@
 package se.lu.nateko.cp.meta.test
 
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.onto.{InstOnto, Onto}
 
@@ -9,6 +10,7 @@ class InstOntoTests extends AnyFunSpec{
 
 	val onto = new Onto(TestConfig.owlOnto)
 	val instOnto = new InstOnto(TestConfig.instServer, onto)
+	val stationClassUri = new URI(TestConfig.ontUri + "Station")
 
 	describe("getIndividual"){
 
@@ -29,6 +31,47 @@ class InstOntoTests extends AnyFunSpec{
 			val globalBox = new URI(TestConfig.instOntUri + "globalLatLonBox")
 			val range = instOnto.getRangeValues(stationClass, spatialCovProp)
 			assert(range.map(_.uri).contains(globalBox))
+		}
+	}
+
+	describe("getIndividualsSparql"){
+
+		it("includes basic query structure and common projected properties"){
+			val query = instOnto.getIndividualsSparql(stationClassUri, None)
+
+			assert(query.contains("SELECT ?s"))
+			assert(query.contains(s"?s rdf:type <$stationClassUri> ."))
+			assert(query.contains("ORDER BY ?s"))
+			assert(query.contains("rdfs:label"))
+			assert(query.contains("rdfs:comment"))
+		}
+
+		it("includes subject prefix filter when provided"){
+			val prefix = "http://meta.icos-cp.eu/"
+			val query = instOnto.getIndividualsSparql(stationClassUri, Some(prefix))
+
+			assert(query.contains(s"FILTER(STRSTARTS(STR(?s), \"$prefix\"))"))
+		}
+
+		it("omits subject prefix filter when not provided"){
+			val query = instOnto.getIndividualsSparql(stationClassUri, None)
+
+			assert(!query.contains("STRSTARTS(STR(?s),"))
+		}
+
+		it("escapes quotes and backslashes in subject prefix"){
+			val prefix = "http://meta.icos-cp.eu/path\\with\\slash/\"quoted\""
+			val query = instOnto.getIndividualsSparql(stationClassUri, Some(prefix))
+
+			assert(query.contains("path\\\\with\\\\slash"))
+			assert(query.contains("\\\"quoted\\\""))
+		}
+
+		it("produces a syntactically valid SPARQL query"){
+			val query = instOnto.getIndividualsSparql(stationClassUri, Some("http://meta.icos-cp.eu/"))
+
+			(new SPARQLParser).parseQuery(query, null)
+			assert(true)
 		}
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala
@@ -1,8 +1,10 @@
 package se.lu.nateko.cp.meta.test
 
 import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser
+import org.eclipse.rdf4j.query.parser.ParsedTupleQuery
 import org.scalatest.funspec.AnyFunSpec
 import se.lu.nateko.cp.meta.onto.{InstOnto, Onto}
+import scala.jdk.CollectionConverters.SetHasAsScala
 
 import java.net.URI
 
@@ -11,6 +13,10 @@ class InstOntoTests extends AnyFunSpec{
 	val onto = new Onto(TestConfig.owlOnto)
 	val instOnto = new InstOnto(TestConfig.instServer, onto)
 	val stationClassUri = new URI(TestConfig.ontUri + "Station")
+	private def parseTupleQuery(query: String): ParsedTupleQuery =
+		(new SPARQLParser).parseQuery(query, null) match
+			case parsed: ParsedTupleQuery => parsed
+			case other => fail(s"Expected ParsedTupleQuery, got ${other.getClass.getSimpleName}")
 
 	describe("getIndividual"){
 
@@ -35,43 +41,32 @@ class InstOntoTests extends AnyFunSpec{
 	}
 
 	describe("getIndividualsSparql"){
-
 		it("includes basic query structure and common projected properties"){
 			val query = instOnto.getIndividualsSparql(stationClassUri, None)
+			val parsed = parseTupleQuery(query)
+			val bindingNames = parsed.getTupleExpr.nn.getBindingNames.nn.asScala
 
-			assert(query.contains("SELECT ?s"))
+			assert(bindingNames.contains("s"))
+			assert(bindingNames.contains("label"))
+			assert(bindingNames.contains("comment"))
+			assert(bindingNames.contains("seeAlso"))
 			assert(query.contains(s"?s rdf:type <$stationClassUri> ."))
 			assert(query.contains("ORDER BY ?s"))
-			assert(query.contains("rdfs:label"))
-			assert(query.contains("rdfs:comment"))
 		}
 
 		it("includes subject prefix filter when provided"){
-			val prefix = "http://meta.icos-cp.eu/"
+			val prefix = new URI("http://meta.icos-cp.eu/")
 			val query = instOnto.getIndividualsSparql(stationClassUri, Some(prefix))
+			parseTupleQuery(query)
 
-			assert(query.contains(s"FILTER(STRSTARTS(STR(?s), \"$prefix\"))"))
+			assert(query.contains(s"""FILTER(STRSTARTS(STR(?s), "$prefix"))"""))
 		}
 
 		it("omits subject prefix filter when not provided"){
 			val query = instOnto.getIndividualsSparql(stationClassUri, None)
+			parseTupleQuery(query)
 
 			assert(!query.contains("STRSTARTS(STR(?s),"))
-		}
-
-		it("escapes quotes and backslashes in subject prefix"){
-			val prefix = "http://meta.icos-cp.eu/path\\with\\slash/\"quoted\""
-			val query = instOnto.getIndividualsSparql(stationClassUri, Some(prefix))
-
-			assert(query.contains("path\\\\with\\\\slash"))
-			assert(query.contains("\\\"quoted\\\""))
-		}
-
-		it("produces a syntactically valid SPARQL query"){
-			val query = instOnto.getIndividualsSparql(stationClassUri, Some("http://meta.icos-cp.eu/"))
-
-			(new SPARQLParser).parseQuery(query, null)
-			assert(true)
 		}
 	}
 }

--- a/src/test/scala/se/lu/nateko/cp/meta/test/routes/MetadataEntryRoutingTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/routes/MetadataEntryRoutingTests.scala
@@ -1,0 +1,45 @@
+package se.lu.nateko.cp.meta.test.routes
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.Host
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import eu.icoscp.envri.Envri
+import org.scalatest.funspec.AnyFunSpec
+import se.lu.nateko.cp.cpauth.core.PublicAuthConfig
+import se.lu.nateko.cp.meta.onto.{InstOnto, Onto}
+import se.lu.nateko.cp.meta.routes.{AuthenticationRouting, MetadataEntryRouting}
+import se.lu.nateko.cp.meta.test.TestConfig
+import se.lu.nateko.cp.meta.test.TestConfig.given
+import spray.json.*
+import spray.json.DefaultJsonProtocol.*
+
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+class MetadataEntryRoutingTests extends AnyFunSpec with ScalatestRouteTest:
+
+	private val onto = new Onto(TestConfig.owlOnto)
+	private val instOnto = new InstOnto(TestConfig.instServer, onto)
+	private val authRouting = new AuthenticationRouting(Map.empty[Envri, PublicAuthConfig])
+	private val route = new MetadataEntryRouting(authRouting).singleOntoRoute(instOnto, Seq.empty)
+
+	private val classUri = new URI(TestConfig.ontUri + "Station")
+	private val encodedClassUri = URLEncoder.encode(classUri.toString, StandardCharsets.UTF_8)
+
+	describe("MetadataEntryRouting getIndividualsSparql"):
+
+		it("returns a query payload for a recognized ENVRI host"):
+			Get(s"/getIndividualsSparql?classUri=$encodedClassUri")
+				.withHeaders(Host("meta.icos-cp.eu")) ~> route ~> check:
+					assert(status === StatusCodes.OK)
+					val responseJson = responseAs[String].parseJson.asJsObject
+					val query = responseJson.fields("query").convertTo[String]
+					assert(query.contains("SELECT ?s"))
+					assert(query.contains("FILTER(STRSTARTS(STR(?s), \"http://meta.icos-cp.eu/\"))"))
+
+		it("returns bad request for unknown host"):
+			Get(s"/getIndividualsSparql?classUri=$encodedClassUri")
+				.withHeaders(Host("unknown.example.org")) ~> route ~> check:
+					assert(status === StatusCodes.BadRequest)
+					assert(responseAs[String].contains("Unexpected host"))

--- a/src/test/scala/se/lu/nateko/cp/meta/test/routes/MetadataEntryRoutingTests.scala
+++ b/src/test/scala/se/lu/nateko/cp/meta/test/routes/MetadataEntryRoutingTests.scala
@@ -36,7 +36,7 @@ class MetadataEntryRoutingTests extends AnyFunSpec with ScalatestRouteTest:
 					val responseJson = responseAs[String].parseJson.asJsObject
 					val query = responseJson.fields("query").convertTo[String]
 					assert(query.contains("SELECT ?s"))
-					assert(query.contains("FILTER(STRSTARTS(STR(?s), \"http://meta.icos-cp.eu/\"))"))
+					assert(query.contains("""FILTER(STRSTARTS(STR(?s), "http://meta.icos-cp.eu/"))"""))
 
 		it("returns bad request for unknown host"):
 			Get(s"/getIndividualsSparql?classUri=$encodedClassUri")


### PR DESCRIPTION
This adds a button in the metadata editor that link to a SPARQL query that should give a list of individuals for the currently selected type. The button can be seen at https://metastaging.icos-cp.eu/edit/cpmeta/ right now and looks like:
<img width="548" height="201" alt="SPARQL button" src="https://github.com/user-attachments/assets/adab188c-3515-4a9e-b9db-1175364e6f09" />

The important parts to review would be the main logic `src/main/scala/se/lu/nateko/cp/meta/onto/InstOnto.scala` and the tests `src/test/scala/se/lu/nateko/cp/meta/test/InstOntoTests.scala` and `src/test/scala/se/lu/nateko/cp/meta/test/routes/MetadataEntryRoutingTests.scala`.