### PR TITLE
Adjust info displayed as key figures on station landing pages

### DIFF
--- a/src/main/twirl/views/StationLandingPage.scala.html
+++ b/src/main/twirl/views/StationLandingPage.scala.html
@@ -244,7 +244,7 @@
 		<div class="rounded-circle d-flex align-items-center justify-content-center bg-primary" style="height: 72px; width: 72px;">
 			<i class="fas @icon fs-1 text-light"></i>
 		</div>
-		<div class="fs-3 fw-semibold text-center">@value</div>
+		<div class="@if(value.length >= 25){fs-lg} else {fs-3} fw-semibold text-center">@value</div>
 		@for(descr <- descr){
 			<div class="text-dark @if(envri != Envri.SITES){fw-semibold} text-center">@descr</div>
 		}

--- a/src/main/twirl/views/StationLandingPage.scala.html
+++ b/src/main/twirl/views/StationLandingPage.scala.html
@@ -90,9 +90,6 @@
 						@for(meanAnnualPrecip <- ecoSpecifics.flatMap(_.meanAnnualPrecip)){
 							@quickfact(s"$meanAnnualPrecip mm", "fa-cloud-rain", Some("Mean annual precipitation"))
 						}
-						@for(climateZone <- ecoSpecifics.flatMap(_.climateZone).flatMap(_.label)){
-							@quickfact(climateZone, "fa-image", Some("Climate zone"))
-						}
 					</div>
 				</div>
 			</div>
@@ -244,7 +241,7 @@
 		<div class="rounded-circle d-flex align-items-center justify-content-center bg-primary" style="height: 72px; width: 72px;">
 			<i class="fas @icon fs-1 text-light"></i>
 		</div>
-		<div class="@if(value.length >= 25){fs-lg} else {fs-3} fw-semibold text-center">@value</div>
+		<div class="fs-3 fw-semibold text-center">@value</div>
 		@for(descr <- descr){
 			<div class="text-dark @if(envri != Envri.SITES){fw-semibold} text-center">@descr</div>
 		}


### PR DESCRIPTION
Remove climate zone info as the text does not fit properly in the format. Consider adding climate info or other info based on feedback from Station PIs.