### PR TITLE
Add operationalPeriod to OTC station flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val metaCore = (project in file("core"))
 	.enablePlugins(IcosCpSbtCodeGenPlugin)
 	.settings(
 		name := "meta-core",
-		version := "0.7.24",
+		version := "0.7.25",
 		scalacOptions ++= commonScalacOptions,
 		libraryDependencies ++= Seq(
 			"io.spray"              %% "spray-json"                         % "1.3.6",

--- a/core/src/main/scala/data/JsonSupport.scala
+++ b/core/src/main/scala/data/JsonSupport.scala
@@ -243,7 +243,7 @@ object JsonSupport extends CommonJsonSupport:
 	given JsonFormat[IcosStationClass] = enumFormat(IcosStationClass.valueOf, IcosStationClass.values)
 	given RootJsonFormat[AtcStationSpecifics] = jsonFormat7(AtcStationSpecifics.apply)
 	given RootJsonFormat[EtcStationSpecifics] = jsonFormat13(EtcStationSpecifics.apply)
-	given RootJsonFormat[OtcStationSpecifics] = jsonFormat6(OtcStationSpecifics.apply)
+	given RootJsonFormat[OtcStationSpecifics] = jsonFormat7(OtcStationSpecifics.apply)
 	given RootJsonFormat[SitesStationSpecifics] = jsonFormat8(SitesStationSpecifics.apply)
 	given JsonFormat[CityNetwork] with
 		def write(cn: CityNetwork): JsValue = JsString(cn.toString)
@@ -281,4 +281,3 @@ object JsonSupport extends CommonJsonSupport:
 	}
 
 end JsonSupport
-

--- a/core/src/main/scala/data/Station.scala
+++ b/core/src/main/scala/data/Station.scala
@@ -105,6 +105,7 @@ case class OtcStationSpecifics(
 	stationClass: Option[IcosStationClass],
 	labelingDate: Option[LocalDate],
 	discontinued: Boolean,
+	operationalPeriod: Option[String],
 	timeZoneOffset: Option[Int],
 	documentation: Seq[PlainStaticObject]
 ) extends IcosStationSpecifics

--- a/core/src/main/scala/data/Station.scala
+++ b/core/src/main/scala/data/Station.scala
@@ -47,7 +47,9 @@ enum FunderIdType:
 
 case class Funder(org: Organization, id: Option[(String, FunderIdType)])
 
-case object NoStationSpecifics extends StationSpecifics
+case object NoStationSpecifics extends StationSpecifics{
+	override def operationalPeriod: Option[String] = None
+}
 
 sealed trait EcoStationSpecifics extends StationSpecifics{
 	def climateZone: Option[UriResource]
@@ -76,7 +78,9 @@ sealed trait IcosStationSpecifics extends StationSpecifics{
 	def documentation: Seq[PlainStaticObject]
 }
 
-sealed trait StationSpecifics
+sealed trait StationSpecifics{
+	def operationalPeriod: Option[String]
+}
 
 case class AtcStationSpecifics(
 	wigosId: Option[String],
@@ -86,7 +90,9 @@ case class AtcStationSpecifics(
 	discontinued: Boolean,
 	timeZoneOffset: Option[Int],
 	documentation: Seq[PlainStaticObject]
-) extends IcosStationSpecifics
+) extends IcosStationSpecifics{
+	override def operationalPeriod: Option[String] = None
+}
 
 object AtcStationSpecifics{
 	def apply(base: IcosStationSpecifics, wigosId: Option[String]): AtcStationSpecifics = AtcStationSpecifics(
@@ -126,6 +132,7 @@ case class EtcStationSpecifics(
 	documentation: Seq[PlainStaticObject]
 ) extends IcosStationSpecifics with EcoStationSpecifics{
 	override def ecosystems = ecosystemType.toSeq
+	override def operationalPeriod: Option[String] = None
 }
 
 //TODO Consider removing "Unspecified" option later
@@ -141,7 +148,9 @@ def cityNetworkFromStr(s: String): CityNetwork = s match
 case class IcosCitiesStationSpecifics(
 	timeZoneOffset: Option[Int],
 	network: CityNetwork
-) extends StationSpecifics
+) extends StationSpecifics{
+	override def operationalPeriod: Option[String] = None
+}
 
 object EtcStationSpecifics{
 	def apply(base: IcosStationSpecifics): EtcStationSpecifics = EtcStationSpecifics(

--- a/core/src/test/scala/TestFactory.scala
+++ b/core/src/test/scala/TestFactory.scala
@@ -108,6 +108,7 @@ object TestFactory:
 			stationClass = None,
 			labelingDate = None,
 			discontinued = discontinued,
+			operationalPeriod = None,
 			timeZoneOffset = None,
 			documentation = Nil
 		)

--- a/src/main/resources/owl/otcmeta.owl
+++ b/src/main/resources/owl/otcmeta.owl
@@ -699,6 +699,17 @@
     
 
 
+    <!-- http://meta.icos-cp.eu/ontologies/otcmeta/hasOperationalPeriod -->
+
+    <owl:DatatypeProperty rdf:about="http://meta.icos-cp.eu/ontologies/otcmeta/hasOperationalPeriod">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="http://meta.icos-cp.eu/ontologies/otcmeta/Station"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+        <rdfs:label>operational period</rdfs:label>
+    </owl:DatatypeProperty>
+    
+
+
     <!-- http://meta.icos-cp.eu/ontologies/otcmeta/hasOrcidId -->
 
     <owl:DatatypeProperty rdf:about="http://meta.icos-cp.eu/ontologies/otcmeta/hasOrcidId">

--- a/src/main/scala/metaflow/RdfMaker.scala
+++ b/src/main/scala/metaflow/RdfMaker.scala
@@ -12,6 +12,7 @@ import se.lu.nateko.cp.meta.core.data.{
 	StationSpecifics,
 	EtcStationSpecifics,
 	AtcStationSpecifics,
+	OtcStationSpecifics,
 	IcosStationSpecifics,
 	IcosCitiesStationSpecifics,
 	SitesStationSpecifics,
@@ -233,8 +234,11 @@ class RdfMaker(vocab: CpVocab, val meta: CpmetaVocab)(using Envri) {
 				(iri, meta.hasWigosId, vocab.lit(wigosId))
 			} ++
 			plainIcosStationSpecTriples(iri, atc)
-		case icos: IcosStationSpecifics =>
-			plainIcosStationSpecTriples(iri, icos)
+		case otc: OtcStationSpecifics =>
+			otc.operationalPeriod.toSeq.map{period =>
+				(iri, meta.hasOperationalPeriod, vocab.lit(period))
+			} ++
+			plainIcosStationSpecTriples(iri, otc)
 		case cities: IcosCitiesStationSpecifics =>
 			(iri, meta.belongsToNetwork, vocab.lit(cities.network.toString)) +:
 			cities.timeZoneOffset.toSeq.map: tzoff =>

--- a/src/main/scala/metaflow/icos/OtcMetaSource.scala
+++ b/src/main/scala/metaflow/icos/OtcMetaSource.scala
@@ -64,6 +64,7 @@ class OtcMetaSource(
 			|	optional {?plat rdfs:seeAlso ?seeAlsoPlat }
 			|	optional {?st otc:countryCode ?countryCode }
 			|	optional {?st otc:hasStationClass ?stationClass }
+			|	optional {?st otc:hasOperationalPeriod ?operationalPeriod }
 			|	optional {?st otc:hasResponsibleOrg ?respOrg }
 			|	optional {?st rdfs:seeAlso ?seeAlsoSt }
 			|}
@@ -77,6 +78,7 @@ class OtcMetaSource(
 				lonOpt <- qresValue(b, "lon").flatMap(parseDouble).optional;
 				geoJsonOpt <- qresValue(b, "geoJson").map(_.stringValue).optional;
 				statClass <- qresValue(b, "stationClass").map(v => IcosStationClass.valueOf(v.stringValue)).optional;
+				operationalPeriod <- qresValue(b, "operationalPeriod").map(_.stringValue).optional;
 				ccode <- qresValue(b, "countryCode").flatMap{v =>
 					val ccStr = v.stringValue
 					CountryCode.unapply(ccStr).fold(Validated.error(s"Bad country code $ccStr")){
@@ -116,7 +118,15 @@ class OtcMetaSource(
 						responsibleOrganization = None,
 						pictures = pictUri.toSeq,
 						countryCode = ccode,
-						specificInfo = OtcStationSpecifics(None, statClass, None, false, None, Seq.empty),
+						specificInfo = OtcStationSpecifics(
+							theme = None,
+							stationClass = statClass,
+							labelingDate = None,
+							discontinued = false,
+							operationalPeriod = operationalPeriod,
+							timeZoneOffset = None,
+							documentation = Seq.empty
+						),
 						funding = None,
 						networks = Nil
 					),
@@ -340,4 +350,3 @@ class OtcMetaVocab(val factory: ValueFactory) extends CustomVocab{
 		)
 	}
 }
-

--- a/src/main/scala/services/upload/DobjMetaReader.scala
+++ b/src/main/scala/services/upload/DobjMetaReader.scala
@@ -194,6 +194,7 @@ trait DobjMetaReader(val vocab: CpVocab) extends CpmetaReader:
 			themeUri <- getOptionalUri(thematicCenter, metaVocab.hasDataTheme)
 			theme <- themeUri.map(getDataTheme).sinkOption
 			stationClass <- getOptionalString(stat, metaVocab.hasStationClass)
+			operationalPeriod <- getOptionalString(stat, metaVocab.hasOperationalPeriod)
 			timeZoneOffset <- getOptionalInt(stat, metaVocab.hasTimeZoneOffset)
 			discontOpt <- getOptionalBool(stat, metaVocab.isDiscontinued)
 			documentation <- getDocumentationObjs(stat)
@@ -203,6 +204,7 @@ trait DobjMetaReader(val vocab: CpVocab) extends CpmetaReader:
 				stationClass = stationClass.map(IcosStationClass.valueOf),
 				labelingDate = lblDate,
 				discontinued = discontOpt.getOrElse(false),
+				operationalPeriod = operationalPeriod,
 				timeZoneOffset = timeZoneOffset,
 				documentation = documentation
 			)

--- a/src/main/twirl/views/StationLandingPage.scala.html
+++ b/src/main/twirl/views/StationLandingPage.scala.html
@@ -176,6 +176,20 @@
 	}
 }
 
+@otcSpecifics = @{
+	Option(station.specificInfo).collect{
+		case otc: OtcStationSpecifics => otc
+	}
+}
+
+@operationalPeriod = @{
+	station.specificInfo match {
+		case sites: SitesStationSpecifics => sites.operationalPeriod
+		case otc: OtcStationSpecifics => otc.operationalPeriod
+		case _ => None
+	}
+}
+
 @ecoSpecifics = @{
 	Option(station.specificInfo).collect{
 		case eco: EcoStationSpecifics => eco
@@ -346,10 +360,8 @@
 			}
 		}
 	}
-	@for(sites <- sitesSpecifics){
-		@for(operationalPeriod <- sites.operationalPeriod) {
-			@property("Operational period", operationalPeriod)
-		}
+	@for(period <- operationalPeriod) {
+		@property("Operational period", period)
 	}
 	@for(document <- stationDocs) {
 		@htmlProperty{Documentation}{<a href=@{document.res.getRawPath}>@{document.name}</a>}

--- a/src/main/twirl/views/StationLandingPage.scala.html
+++ b/src/main/twirl/views/StationLandingPage.scala.html
@@ -183,11 +183,7 @@
 }
 
 @operationalPeriod = @{
-	station.specificInfo match {
-		case sites: SitesStationSpecifics => sites.operationalPeriod
-		case otc: OtcStationSpecifics => otc.operationalPeriod
-		case _ => None
-	}
+	station.specificInfo.operationalPeriod
 }
 
 @ecoSpecifics = @{


### PR DESCRIPTION
OTC will be able to provide an operational period string in https://meta.icos-cp.eu/edit/otcentry/ which will end up in the production metadata https://meta.icos-cp.eu/edit/icosmeta/. The property will be visible on the station pages and available in SPARQL using the `http://meta.icos-cp.eu/ontologies/cpmeta/hasOperationalPeriod` predicate.