### PR TITLE
Print missing DOI or citation cache error

### DIFF
--- a/src/main/scala/services/citation/CitationClient.scala
+++ b/src/main/scala/services/citation/CitationClient.scala
@@ -24,6 +24,7 @@ import se.lu.nateko.cp.meta.utils.async.errorLite
 import se.lu.nateko.cp.meta.utils.async.timeLimit
 
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
@@ -247,6 +248,9 @@ object CitationClient:
 				case _ => throw Exception("Citation/DOI dump was not a JSON array")
 			TrieMap.apply(tuples*)
 		}.recover{
+			case _: NoSuchFileException =>
+				log.info(s"Cache dump $file does not exist; starting with empty cache")
+				TrieMap.empty
 			case err: Throwable =>
 				log.error("Could not read cache dump", err)
 				TrieMap.empty


### PR DESCRIPTION
Until now, we threw exceptions if the DOI or citation caches are missing:
```
[ERROR] CitationClient$ Could not read cache dump 
 java.nio.file.NoSuchFileException: ./doiMetaCacheDump.json
 	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
 	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
 	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
 	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:261)
 	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
 	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
 	at java.base/java.nio.file.Files.readAllBytes(Files.java:3281)
 	at java.base/java.nio.file.Files.readString(Files.java:3359)
 	at java.base/java.nio.file.Files.readString(Files.java:3318)
 	at se.lu.nateko.cp.meta.services.citation.CitationClient$.readCache$$anonfun$1(CitationClient.scala:240)
 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
 	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
 	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1423)
 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
 [ERROR] CitationClient$ Could not read cache dump 
 java.nio.file.NoSuchFileException: ./citationsCacheDump.json
 	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
 	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
 	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
 	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:261)
 	at java.base/java.nio.file.Files.newByteChannel(Files.java:380)
 	at java.base/java.nio.file.Files.newByteChannel(Files.java:432)
 	at java.base/java.nio.file.Files.readAllBytes(Files.java:3281)
 	at java.base/java.nio.file.Files.readString(Files.java:3359)
 	at java.base/java.nio.file.Files.readString(Files.java:3318)
 	at se.lu.nateko.cp.meta.services.citation.CitationClient$.readCache$$anonfun$1(CitationClient.scala:240)
 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:687)
 	at scala.concurrent.impl.Promise$Transformation.run(Promise.scala:467)
 	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1423)
 	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
 	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

This change would handle the exceptions and print messages instead:
```
 [INFO] CitationClient$ Cache dump ./doiMetaCacheDump.json does not exist; starting with empty cache 
 [INFO] CitationClient$ Cache dump ./citationsCacheDump.json does not exist; starting with empty cache 
```
These cache files are created when we switch to read-only mode, usually before deploying and restarting the service in staging or production environments. In dev environments, these files are often not present and create unnecessary noise in the console.