### PR TITLE
Improve SPARQL timeout handling and query logging

### DIFF
--- a/src/main/resources/logback-dev.xml
+++ b/src/main/resources/logback-dev.xml
@@ -11,5 +11,6 @@
 	</root>
 
 	<logger name="org.semanticweb.owlapi.rdf.rdfxml.parser.OWLRDFConsumer" level="WARN" />
+	<logger name="se.lu.nateko.cp.meta.sparql.queries" level="INFO" additivity="false" />
 
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -12,11 +12,25 @@
 		<minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
 	</appender>
 
+	<appender name="SPARQL_QUERY" class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<file>${SPARQL_QUERY_LOG_FILE:-sparql-query.log}</file>
+		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<fileNamePattern>${SPARQL_QUERY_LOG_FILE:-sparql-query.log}.%d{yyyy-MM-dd}.gz</fileNamePattern>
+			<maxHistory>14</maxHistory>
+		</rollingPolicy>
+		<encoder>
+			<pattern>%date{ISO8601} %-5level [%logger] [%thread] - %msg%n</pattern>
+		</encoder>
+	</appender>
+
 	<root level="info">
 		<appender-ref ref="STDOUT" />
 		<appender-ref ref="SENTRY" />
 	</root>
 
 	<logger name="org.semanticweb.owlapi.rdf.rdfxml.parser.OWLRDFConsumer" level="WARN" />
+	<logger name="se.lu.nateko.cp.meta.sparql.queries" level="INFO" additivity="false">
+		<appender-ref ref="SPARQL_QUERY" />
+	</logger>
 
 </configuration>

--- a/src/main/scala/routes/SparqlRoute.scala
+++ b/src/main/scala/routes/SparqlRoute.scala
@@ -16,6 +16,7 @@ import akka.http.scaladsl.server.{Directive, Directive0, Directive1, RejectionHa
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Keep, Sink, SinkQueueWithCancel, Source}
 import akka.stream.{Materializer, SinkShape}
 import akka.util.ByteString
+import org.eclipse.rdf4j.query.QueryInterruptedException
 import se.lu.nateko.cp.meta.SparqlServerConfig
 import se.lu.nateko.cp.meta.api.SparqlQuery
 import se.lu.nateko.cp.meta.core.crypto.Sha256Sum
@@ -131,7 +132,7 @@ object SparqlRoute:
 				}
 				resp.withEntity(HttpEntity(resp.entity.contentType, data))
 			.recover:
-				case _: CancellationException =>
+				case _: CancellationException | _: QueryInterruptedException =>
 					HttpResponse(StatusCodes.BadRequest, entity = "SPARQL execution timeout")
 				case err: Throwable =>
 					HttpResponse(StatusCodes.InternalServerError, entity = err.getMessage + "\n" + getStackTrace(err))

--- a/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
@@ -110,7 +110,6 @@ class Rdf4jSparqlServer(
 			val queryHash = shortHash(queryStr.query)
 			val errPromise = Promise[ByteString]()
 			val finalizer = new QueryRunFinalizer(qquoter)
-			val permittedLongRunning = new AtomicBoolean(false)
 			log.info(s"SPARQL query started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash responseType=${protocolOption.responseType}")
 
 			val sparqlEntityBytes: Source[ByteString, NotUsed] = StreamConverters.asOutputStream(streamTimeout).mapMaterializedValue{ outStr =>
@@ -119,8 +118,7 @@ class Rdf4jSparqlServer(
 				val connCloser = new LoggedCloseOnce(s"SPARQL repository connection qid=${qquoter.qid}", conn, log.debug)
 				val streamCloser = new LoggedCloseOnce(s"SPARQL output stream qid=${qquoter.qid}", new AutoCloseable:
 					def close(): Unit =
-						outStr.flush()
-						outStr.close()
+						try outStr.flush() finally outStr.close()
 				, log.debug)
 
 				val (resultCloser, sparqlFut) = Try:
@@ -142,15 +140,15 @@ class Rdf4jSparqlServer(
 							system.scheduler.scheduleOnce(config.maxQueryRuntimeSec.seconds):
 								if !doneFut.isCompleted then
 									if qquoter.keepRunningIndefinitely then
-										permittedLongRunning.set(true)
 										log.info(s"SPARQL query permitted to keep running qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
 									else
 										log.warning(s"SPARQL query exceeded runtime qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash maxRuntimeSec=${config.maxQueryRuntimeSec} action=waiting-for-rdf4j-timeout")
-							system.scheduler.scheduleOnce((config.maxQueryRuntimeSec + 10).seconds):
-								if !doneFut.isCompleted && !permittedLongRunning.get() then
-									log.error(s"SPARQL query still running after grace period qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash action=force-closing-result")
-									errPromise.tryFailure(CancellationException(s"SPARQL query ${qquoter.qid} timed out"))
-									loggedCloser.close()
+										system.scheduler.scheduleOnce(10.seconds):
+											if !doneFut.isCompleted then
+												log.error(s"SPARQL query still running after grace period qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash action=force-closing-result")
+												errPromise.tryFailure(CancellationException(s"SPARQL query ${qquoter.qid} timed out"))
+												loggedCloser.close()
+												connCloser.close()
 							loggedCloser -> doneFut
 					)
 
@@ -162,8 +160,8 @@ class Rdf4jSparqlServer(
 							log.warning(s"SPARQL query failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash error=${err.getClass.getName}: ${err.getMessage}")
 					errPromise.tryComplete(tryDone.map(_ => ByteString.empty))
 					streamCloser.close()
-					finalizer.finish()
 					connCloser.close()
+					finalizer.finish()
 
 				resultCloser
 			}.wireTap:

--- a/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
@@ -24,12 +24,16 @@ import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory
 import se.lu.nateko.cp.meta.SparqlServerConfig
 import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlServer}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
+import se.lu.nateko.cp.meta.services.sparql.QuotaManager.QueryQuotaManager
 
+import java.security.MessageDigest
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.{CancellationException, Executors}
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{ExecutionContext, Future, Promise}
-import scala.util.Try
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
 
 
 class Rdf4jSparqlServer(
@@ -79,63 +83,102 @@ class Rdf4jSparqlServer(
 				plainResponse(StatusCodes.BadRequest, userErr.getMessage)
 		}
 
+	private def shortHash(s: String): String =
+		val md = MessageDigest.getInstance("SHA-256").digest(s.getBytes(java.nio.charset.StandardCharsets.UTF_8))
+		md.take(8).map("%02x".format(_)).mkString
+
+	private final class LoggedCloseOnce(name: String, closeable: AutoCloseable, logFailure: String => Unit) extends AutoCloseable:
+		private val closed = new AtomicBoolean(false)
+		override def close(): Unit =
+			if closed.compareAndSet(false, true) then
+				try closeable.close()
+				catch case NonFatal(err) => logFailure(s"Failed to close $name: ${err.getClass.getName}: ${err.getMessage}")
+
+	private final class QueryRunFinalizer(qquoter: QueryQuotaManager):
+		private val finished = new AtomicBoolean(false)
+		def finish(): Unit =
+			if finished.compareAndSet(false, true) then qquoter.logQueryFinish()
+
 	private def getQueryMarshalling[Q <: Query](
 		queryStr: SparqlQuery,
 		protocolOption: ProtocolOption[Q]
 	): Marshalling[HttpResponse] = Marshalling.WithFixedContentType(
 		protocolOption.requestedResponseType,
 		() => {
-			val timeout = (config.maxQueryRuntimeSec + 1).seconds
+			val streamTimeout = (config.maxQueryRuntimeSec + 1).seconds
 			val qquoter = quoter.getQueryQuotaManager(queryStr.clientId)
+			val queryHash = shortHash(queryStr.query)
 			val errPromise = Promise[ByteString]()
-			val sparqlEntityBytes: Source[ByteString, NotUsed] = StreamConverters.asOutputStream(timeout).mapMaterializedValue{ outStr =>
+			val finalizer = new QueryRunFinalizer(qquoter)
+			val permittedLongRunning = new AtomicBoolean(false)
+			log.info(s"SPARQL query started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash responseType=${protocolOption.responseType}")
+
+			val sparqlEntityBytes: Source[ByteString, NotUsed] = StreamConverters.asOutputStream(streamTimeout).mapMaterializedValue{ outStr =>
 
 				val conn = repo.getConnection()
+				val connCloser = new LoggedCloseOnce(s"SPARQL repository connection qid=${qquoter.qid}", conn, log.debug)
+				val streamCloser = new LoggedCloseOnce(s"SPARQL output stream qid=${qquoter.qid}", new AutoCloseable:
+					def close(): Unit =
+						outStr.flush()
+						outStr.close()
+				, log.debug)
 
-				val (closer, sparqlFut) = Try:
-						conn.prepareQuery(queryStr.query).asInstanceOf[Q]
+				val (resultCloser, sparqlFut) = Try:
+						val query = conn.prepareQuery(queryStr.query).asInstanceOf[Q]
+						query.setMaxExecutionTime(config.maxQueryRuntimeSec)
+						query
 					.flatMap: query =>
 						val sparqlCtxt = ExecutionContext.fromExecutor(qquoter)
 						protocolOption.evaluator.evaluate(query, outStr)(using sparqlCtxt)
 					.fold(
 						err =>
-							val nopCloser = new AutoCloseable:
+							log.warning(s"SPARQL query prepare/evaluate failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash error=${err.getClass.getName}: ${err.getMessage}")
+							(new AutoCloseable:
 								def close(): Unit = ()
-
-							nopCloser -> Future.failed[Done](err)
+							) -> Future.failed[Done](err)
 						,
 						(closer, doneFut) =>
+							val loggedCloser = new LoggedCloseOnce(s"SPARQL result qid=${qquoter.qid}", closer, log.debug)
 							system.scheduler.scheduleOnce(config.maxQueryRuntimeSec.seconds):
 								if !doneFut.isCompleted then
 									if qquoter.keepRunningIndefinitely then
-										log.info(s"Permitting long-running query ${qquoter.qid} from client ${qquoter.cid}")
+										permittedLongRunning.set(true)
+										log.info(s"SPARQL query permitted to keep running qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
 									else
-										log.info(s"Terminating long-running query ${qquoter.qid} from client ${qquoter.cid}")
-										errPromise.tryFailure(CancellationException())
-										closer.close()
-							closer -> doneFut
+										log.warning(s"SPARQL query exceeded runtime qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash maxRuntimeSec=${config.maxQueryRuntimeSec} action=waiting-for-rdf4j-timeout")
+							system.scheduler.scheduleOnce((config.maxQueryRuntimeSec + 10).seconds):
+								if !doneFut.isCompleted && !permittedLongRunning.get() then
+									log.error(s"SPARQL query still running after grace period qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash action=force-closing-result")
+									errPromise.tryFailure(CancellationException(s"SPARQL query ${qquoter.qid} timed out"))
+									loggedCloser.close()
+							loggedCloser -> doneFut
 					)
 
 				sparqlFut.onComplete: tryDone =>
+					tryDone match
+						case Success(_) =>
+							log.info(s"SPARQL query completed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
+						case Failure(err) =>
+							log.warning(s"SPARQL query failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash error=${err.getClass.getName}: ${err.getMessage}")
 					errPromise.tryComplete(tryDone.map(_ => ByteString.empty))
-					try
-						outStr.flush()
-						outStr.close()
-					catch case _: Throwable =>
-						log.debug("SPARQL stream was closed/detached")
-					finally
-						qquoter.logQueryFinish()
-						conn.close()
+					streamCloser.close()
+					finalizer.finish()
+					connCloser.close()
 
-				closer
+				resultCloser
 			}.wireTap:
 				Sink.head[ByteString].mapMaterializedValue(
-					_.foreach(_ => qquoter.logQueryStreamingStart())
+					_.foreach(_ =>
+						log.info(s"SPARQL query streaming started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
+						qquoter.logQueryStreamingStart()
+					)
 				)
 			.watchTermination(): (closer, doneFut) =>
-				doneFut.onComplete(doneTry =>
+				doneFut.onComplete: doneTry =>
+					if !doneTry.isSuccess then
+						log.debug(s"SPARQL response stream terminated qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash result=$doneTry")
 					closer.close()
-				)
+					finalizer.finish()
 				NotUsed
 
 			val entityBytes = sparqlEntityBytes.merge(Source.future(errPromise.future))

--- a/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
@@ -89,12 +89,14 @@ class Rdf4jSparqlServer(
 		val md = MessageDigest.getInstance("SHA-256").digest(s.getBytes(java.nio.charset.StandardCharsets.UTF_8))
 		md.take(8).map("%02x".format(_)).mkString
 
-	private def logSafeQueryText(query: String): String = query
-		.replace("\\", "\\\\")
-		.replace("\r", "\\r")
-		.replace("\n", "\\n")
-		.replace("\t", "\\t")
-		.replace("\"", "\\\"")
+	private def logSafeQueryText(query: String): String =
+		val truncated = if query.length > 10000 then query.take(10000) + "...[truncated]" else query
+		truncated
+			.replace("\\", "\\\\")
+			.replace("\r", "\\r")
+			.replace("\n", "\\n")
+			.replace("\t", "\\t")
+			.replace("\"", "\\\"")
 
 	private final class LoggedCloseOnce(name: String, closeable: AutoCloseable, logFailure: String => Unit) extends AutoCloseable:
 		private val closed = new AtomicBoolean(false)
@@ -170,12 +172,16 @@ class Rdf4jSparqlServer(
 							sparqlQueryLog.info(s"SPARQL query completed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash durationMs=$elapsedMs")
 						case Failure(err) =>
 							log.warning(s"SPARQL query failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash durationMs=$elapsedMs error=${err.getClass.getName}: ${err.getMessage}")
+							sparqlQueryLog.info(s"SPARQL query failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash durationMs=$elapsedMs error=${err.getClass.getName}: ${err.getMessage}")
 					errPromise.tryComplete(tryDone.map(_ => ByteString.empty))
 					streamCloser.close()
 					connCloser.close()
 					finalizer.finish()
 
-				resultCloser
+				new AutoCloseable:
+					def close(): Unit =
+						resultCloser.close()
+						connCloser.close()
 			}.wireTap:
 				Sink.head[ByteString].mapMaterializedValue(
 					_.foreach(_ =>

--- a/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
+++ b/src/main/scala/services/sparql/Rdf4jSparqlServer.scala
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.repository.Repository
 import org.eclipse.rdf4j.rio.RDFWriterFactory
 import org.eclipse.rdf4j.rio.rdfxml.RDFXMLWriterFactory
 import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory
+import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.SparqlServerConfig
 import se.lu.nateko.cp.meta.api.{SparqlQuery, SparqlServer}
 import se.lu.nateko.cp.meta.services.CpmetaVocab
@@ -41,6 +42,7 @@ class Rdf4jSparqlServer(
 	import Rdf4jSparqlServer.*
 
 	private val log = Logging.getLogger(system, this)
+	private val sparqlQueryLog = LoggerFactory.getLogger("se.lu.nateko.cp.meta.sparql.queries")
 	private val sparqlExe = Executors.newCachedThreadPool() //.newFixedThreadPool(3)
 	private val quoter = new QuotaManager(config, sparqlExe)(Instant.now _)
 	private given ExecutionContext = system.dispatcher
@@ -87,6 +89,13 @@ class Rdf4jSparqlServer(
 		val md = MessageDigest.getInstance("SHA-256").digest(s.getBytes(java.nio.charset.StandardCharsets.UTF_8))
 		md.take(8).map("%02x".format(_)).mkString
 
+	private def logSafeQueryText(query: String): String = query
+		.replace("\\", "\\\\")
+		.replace("\r", "\\r")
+		.replace("\n", "\\n")
+		.replace("\t", "\\t")
+		.replace("\"", "\\\"")
+
 	private final class LoggedCloseOnce(name: String, closeable: AutoCloseable, logFailure: String => Unit) extends AutoCloseable:
 		private val closed = new AtomicBoolean(false)
 		override def close(): Unit =
@@ -108,9 +117,11 @@ class Rdf4jSparqlServer(
 			val streamTimeout = (config.maxQueryRuntimeSec + 1).seconds
 			val qquoter = quoter.getQueryQuotaManager(queryStr.clientId)
 			val queryHash = shortHash(queryStr.query)
+			val startedAtNanos = System.nanoTime()
+			def elapsedMs: Long = (System.nanoTime() - startedAtNanos) / 1000000
 			val errPromise = Promise[ByteString]()
 			val finalizer = new QueryRunFinalizer(qquoter)
-			log.info(s"SPARQL query started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash responseType=${protocolOption.responseType}")
+			sparqlQueryLog.info(s"SPARQL query started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash responseType=${protocolOption.responseType} queryLength=${queryStr.query.length} query=\"${logSafeQueryText(queryStr.query)}\"")
 
 			val sparqlEntityBytes: Source[ByteString, NotUsed] = StreamConverters.asOutputStream(streamTimeout).mapMaterializedValue{ outStr =>
 
@@ -140,12 +151,13 @@ class Rdf4jSparqlServer(
 							system.scheduler.scheduleOnce(config.maxQueryRuntimeSec.seconds):
 								if !doneFut.isCompleted then
 									if qquoter.keepRunningIndefinitely then
-										log.info(s"SPARQL query permitted to keep running qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
+										log.info(s"SPARQL query permitted to keep running qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash elapsedMs=$elapsedMs")
+										sparqlQueryLog.info(s"SPARQL query permitted to keep running qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash elapsedMs=$elapsedMs")
 									else
-										log.warning(s"SPARQL query exceeded runtime qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash maxRuntimeSec=${config.maxQueryRuntimeSec} action=waiting-for-rdf4j-timeout")
+										log.warning(s"SPARQL query exceeded runtime qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash maxRuntimeSec=${config.maxQueryRuntimeSec} elapsedMs=$elapsedMs action=waiting-for-rdf4j-timeout")
 										system.scheduler.scheduleOnce(10.seconds):
 											if !doneFut.isCompleted then
-												log.error(s"SPARQL query still running after grace period qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash action=force-closing-result")
+												log.error(s"SPARQL query still running after grace period qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash elapsedMs=$elapsedMs action=force-closing-result")
 												errPromise.tryFailure(CancellationException(s"SPARQL query ${qquoter.qid} timed out"))
 												loggedCloser.close()
 												connCloser.close()
@@ -155,9 +167,9 @@ class Rdf4jSparqlServer(
 				sparqlFut.onComplete: tryDone =>
 					tryDone match
 						case Success(_) =>
-							log.info(s"SPARQL query completed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
+							sparqlQueryLog.info(s"SPARQL query completed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash durationMs=$elapsedMs")
 						case Failure(err) =>
-							log.warning(s"SPARQL query failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash error=${err.getClass.getName}: ${err.getMessage}")
+							log.warning(s"SPARQL query failed qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash durationMs=$elapsedMs error=${err.getClass.getName}: ${err.getMessage}")
 					errPromise.tryComplete(tryDone.map(_ => ByteString.empty))
 					streamCloser.close()
 					connCloser.close()
@@ -167,14 +179,14 @@ class Rdf4jSparqlServer(
 			}.wireTap:
 				Sink.head[ByteString].mapMaterializedValue(
 					_.foreach(_ =>
-						log.info(s"SPARQL query streaming started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash")
+						sparqlQueryLog.info(s"SPARQL query streaming started qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash elapsedMs=$elapsedMs")
 						qquoter.logQueryStreamingStart()
 					)
 				)
 			.watchTermination(): (closer, doneFut) =>
 				doneFut.onComplete: doneTry =>
 					if !doneTry.isSuccess then
-						log.debug(s"SPARQL response stream terminated qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash result=$doneTry")
+						log.debug(s"SPARQL response stream terminated qid=${qquoter.qid} client=${qquoter.cid} hash=$queryHash elapsedMs=$elapsedMs result=$doneTry")
 					closer.close()
 					finalizer.finish()
 				NotUsed

--- a/src/main/scala/utils/rdf4j/package.scala
+++ b/src/main/scala/utils/rdf4j/package.scala
@@ -9,6 +9,7 @@ import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
 import org.eclipse.rdf4j.repository.{Repository, RepositoryConnection}
 import org.eclipse.rdf4j.sail.Sail
+import org.slf4j.LoggerFactory
 import se.lu.nateko.cp.meta.api.RdfLens.GlobConn
 import se.lu.nateko.cp.meta.api.{CloseableIterator, RdfLens}
 import se.lu.nateko.cp.meta.instanceserver.Rdf4jSailConnection
@@ -17,7 +18,18 @@ import java.net.URI as JavaUri
 import java.time.Instant
 import scala.collection.AbstractIterator
 import scala.util.{Try, Using}
+import scala.util.control.NonFatal
 
+
+private val rdf4jLog = LoggerFactory.getLogger("se.lu.nateko.cp.meta.utils.rdf4j")
+
+private def logIfRepositoryProblem(context: String, err: Throwable): Unit =
+	val msg = Option(err.getMessage).getOrElse("")
+	val isLmdbProblem = msg.contains("MDB_") || msg.contains("Permission denied") || err.getStackTrace.exists(_.getClassName.contains("sail.lmdb"))
+	if isLmdbProblem then
+		rdf4jLog.error(s"Repository/LMDB problem during $context; service restart may be required after MDB_BAD_TXN. error=${err.getClass.getName}: $msg", err)
+	else
+		rdf4jLog.warn(s"Repository problem during $context: ${err.getClass.getName}: $msg", err)
 
 
 extension(factory: ValueFactory){
@@ -53,9 +65,17 @@ extension (uri: Uri)
 
 extension [T](res: CloseableIteration[T])
 	def asPlainScalaIterator: Iterator[T] = new AbstractIterator[T]{
-		override def hasNext: Boolean = try res.hasNext() catch case _ => false
+		override def hasNext: Boolean =
+			try res.hasNext()
+			catch case NonFatal(err) =>
+				logIfRepositoryProblem("iteration.hasNext", err)
+				throw err
 
-		override def next(): T = res.next()
+		override def next(): T =
+			try res.next()
+			catch case NonFatal(err) =>
+				logIfRepositoryProblem("iteration.next", err)
+				throw err
 	}
 
 	def asCloseableIterator: CloseableIterator[T] = new Rdf4jIterationIterator(res)
@@ -72,7 +92,11 @@ extension (repo: Repository)
 				conn.commit()
 			catch
 				case err: Throwable =>
-					conn.rollback()
+					logIfRepositoryProblem("transaction", err)
+					try conn.rollback()
+					catch case NonFatal(rollbackErr) =>
+						logIfRepositoryProblem("transaction.rollback", rollbackErr)
+						err.addSuppressed(rollbackErr)
 					throw err
 		}
 
@@ -92,6 +116,7 @@ extension (repo: Repository)
 		}
 		catch{
 			case err: Throwable =>
+				logIfRepositoryProblem("repository access", err)
 				finalCleanup()
 				throw err
 		}
@@ -99,7 +124,11 @@ extension (repo: Repository)
 
 	def accessEagerly[T](accessor: RepositoryConnection => T): T =
 		val conn = repo.getConnection()
-		try accessor(conn) finally conn.close()
+		try accessor(conn)
+		catch case NonFatal(err) =>
+			logIfRepositoryProblem("eager repository access", err)
+			throw err
+		finally conn.close()
 
 end extension
 

--- a/src/main/scala/utils/rdf4j/package.scala
+++ b/src/main/scala/utils/rdf4j/package.scala
@@ -4,6 +4,7 @@ import scala.language.unsafeNulls
 
 import akka.http.scaladsl.model.Uri
 import org.eclipse.rdf4j.common.iteration.CloseableIteration
+import org.eclipse.rdf4j.query.QueryInterruptedException
 import org.eclipse.rdf4j.common.transaction.IsolationLevel
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.model.{IRI, Literal, Statement, Value, ValueFactory}
@@ -70,13 +71,15 @@ extension [T](res: CloseableIteration[T])
 		override def hasNext: Boolean =
 			try res.hasNext()
 			catch case NonFatal(err) =>
-				logIfRepositoryProblem("iteration.hasNext", err)
+				if !err.isInstanceOf[QueryInterruptedException] then
+					logIfRepositoryProblem("iteration.hasNext", err)
 				throw err
 
 		override def next(): T =
 			try res.next()
 			catch case NonFatal(err) =>
-				logIfRepositoryProblem("iteration.next", err)
+				if !err.isInstanceOf[QueryInterruptedException] then
+					logIfRepositoryProblem("iteration.next", err)
 				throw err
 	}
 

--- a/src/main/scala/utils/rdf4j/package.scala
+++ b/src/main/scala/utils/rdf4j/package.scala
@@ -25,7 +25,9 @@ private val rdf4jLog = LoggerFactory.getLogger("se.lu.nateko.cp.meta.utils.rdf4j
 
 private def logIfRepositoryProblem(context: String, err: Throwable): Unit =
 	val msg = Option(err.getMessage).getOrElse("")
-	val isLmdbProblem = msg.contains("MDB_") || msg.contains("Permission denied") || err.getStackTrace.exists(_.getClassName.contains("sail.lmdb"))
+	val isLmdbProblem = msg.contains("MDB_") || msg.contains("Permission denied") ||
+		err.getClass.getName.contains("lmdb") ||
+		err.getStackTrace.exists(_.getClassName.contains("sail.lmdb"))
 	if isLmdbProblem then
 		rdf4jLog.error(s"Repository/LMDB problem during $context; service restart may be required after MDB_BAD_TXN. error=${err.getClass.getName}: $msg", err)
 	else


### PR DESCRIPTION
These changes improve SPARQL timeout handling to reduce the risk of corrupting RDF4J/LMDB transaction state when long-running queries are cancelled:

 - Use RDF4J’s own query timeout via `setMaxExecutionTime`.
 - Avoid immediately force-closing RDF4J query results at timeout.
 - Add a grace-period fallback close if RDF4J timeout does not stop the query.                                                                                   
 - Log SPARQL queries with query id, client IP, hash, response type, query length, time in a separate log file. This would replace the current SPARQL query log done by nginx. 