### PR TITLE
Fix 'select result' button in SPARQL client on Chrome

### DIFF
--- a/src/main/js/sparqlclient/main.js
+++ b/src/main/js/sparqlclient/main.js
@@ -83,13 +83,14 @@ function syntaxHighlight(json) {
 }
 
 function selectText(containerid) {
-	if (document.selection) {
+	if (document.body.createTextRange) {
 		var range = document.body.createTextRange();
 		range.moveToElementText(document.getElementById(containerid));
 		range.select();
 	} else if (window.getSelection) {
 		var range = document.createRange();
-		range.selectNode(document.getElementById(containerid));
+		range.selectNodeContents(document.getElementById(containerid));
+		window.getSelection().removeAllRanges();
 		window.getSelection().addRange(range);
 	}
 }


### PR DESCRIPTION
The "Select result" button does not work in Chrome.

This updates the code to ensure it works consistently across browsers. The `document.body.createTextRange` branch is for Microsoft browsers, while the `window.getSelection` works for most others. The most important part seemed to be using `removeAllRanges` to clear the selection before attempting to select something new.