### PR TITLE
[virtuoso] [experiment] Enrich statements on-the-fly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -167,7 +167,7 @@ lazy val meta = (project in file("."))
 		).value,
 		cpDeployPlaybook := "core.yml",
 		cpDeployPermittedInventories := Some(Seq("production", "staging", "cities")),
-		cpDeployInfraBranch := "master",
+		cpDeployInfraBranch := "valter/test/virtuoso",
 
 		assembly / fullClasspath := {
 			val cp = (assembly / fullClasspath).value

--- a/build.sbt
+++ b/build.sbt
@@ -166,7 +166,7 @@ lazy val meta = (project in file("."))
 			fetchGCMDKeywords
 		).value,
 		cpDeployPlaybook := "core.yml",
-		cpDeployPermittedInventories := Some(Seq("production", "staging", "cities")),
+		cpDeployPermittedInventories := Some(Seq("production", "staging", "cities", "test-fs4")),
 		cpDeployInfraBranch := "valter/test/virtuoso",
 
 		assembly / fullClasspath := {

--- a/src/main/scala/MetaDb.scala
+++ b/src/main/scala/MetaDb.scala
@@ -20,6 +20,7 @@ import se.lu.nateko.cp.meta.services.citation.CitationClient.{CitationCache, Doi
 import se.lu.nateko.cp.meta.services.labeling.StationLabelingService
 import se.lu.nateko.cp.meta.services.linkeddata.{Rdf4jUriSerializer, UriSerializer}
 import se.lu.nateko.cp.meta.services.sparql.{Rdf4jSparqlServer, VirtuosoRepository}
+import se.lu.nateko.cp.meta.services.sparql.enrichment.EnrichingRepository
 import se.lu.nateko.cp.meta.services.upload.etc.EtcUploadTransformer
 import se.lu.nateko.cp.meta.services.upload.{DataObjectInstanceServers, StaticObjectReader, UploadService}
 import se.lu.nateko.cp.meta.services.{FileStorageService, Rdf4jSparqlRunner, ServiceException}
@@ -141,7 +142,7 @@ class MetaDbFactory(using system: ActorSystem, mat: Materializer):
 
 		given EnvriConfigs = config.core.envriConfigs
 
-		val repo = remoteRepo
+		val repo = EnrichingRepository(remoteRepo, citer)
 
 		val ontosFut = Future{makeOntos(config.onto.ontologies)}.andThen:
 			case _ => log.info("ontology servers created")

--- a/src/main/scala/services/sparql/enrichment/EnrichingRepository.scala
+++ b/src/main/scala/services/sparql/enrichment/EnrichingRepository.scala
@@ -1,0 +1,165 @@
+package se.lu.nateko.cp.meta.services.sparql.enrichment
+
+import scala.language.unsafeNulls
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration
+import org.eclipse.rdf4j.model.{IRI, Resource, Value, ValueFactory}
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.{DefaultEvaluationStrategy, EvaluationStatistics}
+import org.eclipse.rdf4j.query.algebra.evaluation.{QueryEvaluationStep, TripleSource}
+import org.eclipse.rdf4j.query.algebra.{QueryRoot, StatementPattern, TupleExpr}
+import org.eclipse.rdf4j.query.parser.QueryParserUtil
+import org.eclipse.rdf4j.query.{BindingSet, Dataset, GraphQuery, Query, QueryLanguage, TupleQuery}
+import org.eclipse.rdf4j.repository.base.{RepositoryConnectionWrapper, RepositoryWrapper}
+import org.eclipse.rdf4j.repository.sail.SailRepository
+import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver
+import org.eclipse.rdf4j.repository.{Repository, RepositoryConnection}
+import org.eclipse.rdf4j.sail.helpers.{AbstractSail, AbstractSailConnection}
+import org.eclipse.rdf4j.sail.{SailConnection, SailException}
+import se.lu.nateko.cp.meta.services.citation.CitationProvider
+
+/**
+ * Keeps normal SPARQL queries on the external repository, while evaluating queries that
+ * can see computed citation statements locally. The local evaluator still reads every
+ * stored statement from the external repository; it does not maintain an RDF store.
+ */
+final class EnrichingRepository(base: Repository, citer: CitationProvider)
+	extends RepositoryWrapper(base) {
+
+	private val computedPredicates = Set(
+		citer.metaVocab.hasBiblioInfo,
+		citer.metaVocab.hasCitationString,
+		citer.metaVocab.dcterms.license
+	)
+	private val localRepo = SailRepository(RepositoryBackedSail(base, StatementsEnricher(citer)))
+	localRepo.init()
+
+	override def getConnection(): RepositoryConnection = {
+		EnrichingRepositoryConnection(this, base.getConnection(), localRepo.getConnection(), computedPredicates)
+	}
+
+	override def shutDown(): Unit = {
+		try { localRepo.shutDown() }
+		finally { base.shutDown() }
+	}
+}
+
+
+private final class EnrichingRepositoryConnection(
+	repository: Repository,
+	base: RepositoryConnection,
+	local: RepositoryConnection,
+	computedPredicates: Set[IRI]
+) extends RepositoryConnectionWrapper(repository, base) {
+
+	private def needsEnrichment(ql: QueryLanguage, query: String, baseUri: String): Boolean = {
+		val parsed = QueryParserUtil.parseQuery(ql, query, baseUri)
+		var result = false
+		parsed.getTupleExpr.visitChildren(new org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor[RuntimeException] {
+			override def meet(pattern: StatementPattern): Unit = {
+				val predicate = pattern.getPredicateVar
+				if (!predicate.hasValue || predicate.getValue.isInstanceOf[IRI] &&
+					computedPredicates.contains(predicate.getValue.asInstanceOf[IRI])
+				) result = true
+			}
+		})
+		result
+	}
+
+	private def target(ql: QueryLanguage, query: String, baseUri: String): RepositoryConnection = {
+		if (needsEnrichment(ql, query, baseUri)) local else base
+	}
+
+	override def prepareQuery(ql: QueryLanguage, query: String, baseUri: String): Query = {
+		target(ql, query, baseUri).prepareQuery(ql, query, baseUri)
+	}
+
+	override def prepareTupleQuery(ql: QueryLanguage, query: String, baseUri: String): TupleQuery = {
+		target(ql, query, baseUri).prepareTupleQuery(ql, query, baseUri)
+	}
+
+	override def prepareGraphQuery(ql: QueryLanguage, query: String, baseUri: String): GraphQuery = {
+		target(ql, query, baseUri).prepareGraphQuery(ql, query, baseUri)
+	}
+
+	override def getStatements(
+		subj: Resource, pred: IRI, obj: Value, includeInferred: Boolean, contexts: Resource*
+	) = {
+		local.getStatements(subj, pred, obj, includeInferred, contexts*)
+	}
+
+	override def close(): Unit = {
+		try { local.close() }
+		finally { super.close() }
+	}
+}
+
+
+private final class RepositoryBackedSail(base: Repository, enricher: StatementsEnricher) extends AbstractSail {
+	private val serviceResolver = SPARQLServiceResolver()
+
+	override def getValueFactory(): ValueFactory = base.getValueFactory
+	override def isWritable(): Boolean = false
+	override protected def getConnectionInternal(): SailConnection = {
+		RepositoryBackedSailConnection(this, base.getConnection(), enricher, serviceResolver)
+	}
+	override protected def shutDownInternal(): Unit = serviceResolver.shutDown()
+}
+
+
+private final class RepositoryBackedSailConnection(
+	sail: RepositoryBackedSail,
+	base: RepositoryConnection,
+	enricher: StatementsEnricher,
+	serviceResolver: FederatedServiceResolver
+) extends AbstractSailConnection(sail) {
+
+	private val tripleSource = new TripleSource {
+		override def getValueFactory(): ValueFactory = base.getValueFactory
+		override def getStatements(subj: Resource, pred: IRI, obj: Value, contexts: Resource*) = {
+			enricher.enrich(base.getStatements(subj, pred, obj, false, contexts*), subj, pred, obj)
+		}
+	}
+
+	override protected def evaluateInternal(
+		tupleExpr: TupleExpr, dataset: Dataset, bindings: BindingSet, includeInferred: Boolean
+	): CloseableIteration[? <: BindingSet] = {
+		try {
+			val root = tupleExpr.clone() match {
+				case queryRoot: QueryRoot => queryRoot
+				case expression => QueryRoot(expression)
+			}
+			val stats = EvaluationStatistics()
+			val strategy = DefaultEvaluationStrategy(tripleSource, dataset, serviceResolver, 0, stats)
+			val optimized = strategy.optimize(root, stats, bindings)
+			val step: QueryEvaluationStep = strategy.precompile(optimized)
+			step.evaluate(bindings)
+		} catch {
+			case err => throw SailException(err)
+		}
+	}
+
+	override protected def getStatementsInternal(
+		subj: Resource, pred: IRI, obj: Value, includeInferred: Boolean, contexts: Resource*
+	) = {
+		enricher.enrich(base.getStatements(subj, pred, obj, includeInferred, contexts*), subj, pred, obj)
+	}
+
+	override protected def getContextIDsInternal() = base.getContextIDs()
+	override protected def sizeInternal(contexts: Resource*): Long = base.size(contexts*)
+	override protected def getNamespacesInternal() = base.getNamespaces()
+	override protected def getNamespaceInternal(prefix: String): String = base.getNamespace(prefix)
+
+	override protected def closeInternal(): Unit = base.close()
+	override protected def startTransactionInternal(): Unit = ()
+	override protected def commitInternal(): Unit = ()
+	override protected def rollbackInternal(): Unit = ()
+
+	private def readonly(): Nothing = throw SailException("The enriching repository is read-only")
+	override protected def addStatementInternal(subj: Resource, pred: IRI, obj: Value, contexts: Resource*): Unit = readonly()
+	override protected def removeStatementsInternal(subj: Resource, pred: IRI, obj: Value, contexts: Resource*): Unit = readonly()
+	override protected def clearInternal(contexts: Resource*): Unit = readonly()
+	override protected def setNamespaceInternal(prefix: String, name: String): Unit = readonly()
+	override protected def removeNamespaceInternal(prefix: String): Unit = readonly()
+	override protected def clearNamespacesInternal(): Unit = readonly()
+}

--- a/src/main/scala/services/sparql/enrichment/EnrichingRepository.scala
+++ b/src/main/scala/services/sparql/enrichment/EnrichingRepository.scala
@@ -7,6 +7,7 @@ import org.eclipse.rdf4j.model.{IRI, Resource, Value, ValueFactory}
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.{DefaultEvaluationStrategy, EvaluationStatistics}
 import org.eclipse.rdf4j.query.algebra.evaluation.{QueryEvaluationStep, TripleSource}
+import org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor
 import org.eclipse.rdf4j.query.algebra.{QueryRoot, StatementPattern, TupleExpr}
 import org.eclipse.rdf4j.query.parser.QueryParserUtil
 import org.eclipse.rdf4j.query.{BindingSet, Dataset, GraphQuery, Query, QueryLanguage, TupleQuery}
@@ -24,41 +25,41 @@ import se.lu.nateko.cp.meta.services.citation.CitationProvider
  * stored statement from the external repository; it does not maintain an RDF store.
  */
 final class EnrichingRepository(base: Repository, citer: CitationProvider)
-	extends RepositoryWrapper(base) {
+	 extends RepositoryWrapper(base) {
 
 	private val computedPredicates = Set(
 		citer.metaVocab.hasBiblioInfo,
 		citer.metaVocab.hasCitationString,
 		citer.metaVocab.dcterms.license
 	)
-	private val localRepo = SailRepository(RepositoryBackedSail(base, StatementsEnricher(citer)))
-	localRepo.init()
+	private val enrichmentRepo = SailRepository(RepositoryBackedSail(base, StatementsEnricher(citer)))
+	enrichmentRepo.init()
 
 	override def getConnection(): RepositoryConnection = {
-		EnrichingRepositoryConnection(this, base.getConnection(), localRepo.getConnection(), computedPredicates)
+		EnrichingRepositoryConnection(this, base.getConnection(), enrichmentRepo.getConnection(), computedPredicates)
 	}
 
 	override def shutDown(): Unit = {
-		try { localRepo.shutDown() }
-		finally { base.shutDown() }
+		try enrichmentRepo.shutDown()
+		finally base.shutDown()
 	}
 }
-
 
 private final class EnrichingRepositoryConnection(
 	repository: Repository,
 	base: RepositoryConnection,
-	local: RepositoryConnection,
+	enriched: RepositoryConnection,
 	computedPredicates: Set[IRI]
 ) extends RepositoryConnectionWrapper(repository, base) {
 
 	private def needsEnrichment(ql: QueryLanguage, query: String, baseUri: String): Boolean = {
 		val parsed = QueryParserUtil.parseQuery(ql, query, baseUri)
 		var result = false
-		parsed.getTupleExpr.visitChildren(new org.eclipse.rdf4j.query.algebra.helpers.AbstractQueryModelVisitor[RuntimeException] {
+		parsed.getTupleExpr.visitChildren(new AbstractQueryModelVisitor[RuntimeException] {
 			override def meet(pattern: StatementPattern): Unit = {
 				val predicate = pattern.getPredicateVar
-				if (!predicate.hasValue || predicate.getValue.isInstanceOf[IRI] &&
+				if (
+					!predicate.hasValue || predicate.getValue.isInstanceOf[IRI] &&
 					computedPredicates.contains(predicate.getValue.asInstanceOf[IRI])
 				) result = true
 			}
@@ -67,7 +68,7 @@ private final class EnrichingRepositoryConnection(
 	}
 
 	private def target(ql: QueryLanguage, query: String, baseUri: String): RepositoryConnection = {
-		if (needsEnrichment(ql, query, baseUri)) local else base
+		if (needsEnrichment(ql, query, baseUri)) enriched else base
 	}
 
 	override def prepareQuery(ql: QueryLanguage, query: String, baseUri: String): Query = {
@@ -83,17 +84,20 @@ private final class EnrichingRepositoryConnection(
 	}
 
 	override def getStatements(
-		subj: Resource, pred: IRI, obj: Value, includeInferred: Boolean, contexts: Resource*
+		subj: Resource,
+		pred: IRI,
+		obj: Value,
+		includeInferred: Boolean,
+		contexts: Resource*
 	) = {
-		local.getStatements(subj, pred, obj, includeInferred, contexts*)
+		enriched.getStatements(subj, pred, obj, includeInferred, contexts*)
 	}
 
 	override def close(): Unit = {
-		try { local.close() }
-		finally { super.close() }
+		try enriched.close()
+		finally super.close()
 	}
 }
-
 
 private final class RepositoryBackedSail(base: Repository, enricher: StatementsEnricher) extends AbstractSail {
 	private val serviceResolver = SPARQLServiceResolver()
@@ -105,7 +109,6 @@ private final class RepositoryBackedSail(base: Repository, enricher: StatementsE
 	}
 	override protected def shutDownInternal(): Unit = serviceResolver.shutDown()
 }
-
 
 private final class RepositoryBackedSailConnection(
 	sail: RepositoryBackedSail,
@@ -122,7 +125,10 @@ private final class RepositoryBackedSailConnection(
 	}
 
 	override protected def evaluateInternal(
-		tupleExpr: TupleExpr, dataset: Dataset, bindings: BindingSet, includeInferred: Boolean
+		tupleExpr: TupleExpr,
+		dataset: Dataset,
+		bindings: BindingSet,
+		includeInferred: Boolean
 	): CloseableIteration[? <: BindingSet] = {
 		try {
 			val root = tupleExpr.clone() match {
@@ -140,7 +146,11 @@ private final class RepositoryBackedSailConnection(
 	}
 
 	override protected def getStatementsInternal(
-		subj: Resource, pred: IRI, obj: Value, includeInferred: Boolean, contexts: Resource*
+		subj: Resource,
+		pred: IRI,
+		obj: Value,
+		includeInferred: Boolean,
+		contexts: Resource*
 	) = {
 		enricher.enrich(base.getStatements(subj, pred, obj, includeInferred, contexts*), subj, pred, obj)
 	}
@@ -156,8 +166,8 @@ private final class RepositoryBackedSailConnection(
 	override protected def rollbackInternal(): Unit = ()
 
 	private def readonly(): Nothing = throw SailException("The enriching repository is read-only")
-	override protected def addStatementInternal(subj: Resource, pred: IRI, obj: Value, contexts: Resource*): Unit = readonly()
-	override protected def removeStatementsInternal(subj: Resource, pred: IRI, obj: Value, contexts: Resource*): Unit = readonly()
+	override protected def addStatementInternal(subj: Resource, pred: IRI, obj: Value, ctxs: Resource*) = readonly()
+	override protected def removeStatementsInternal(subj: Resource, pred: IRI, obj: Value, ctxs: Resource*) = readonly()
 	override protected def clearInternal(contexts: Resource*): Unit = readonly()
 	override protected def setNamespaceInternal(prefix: String, name: String): Unit = readonly()
 	override protected def removeNamespaceInternal(prefix: String): Unit = readonly()

--- a/src/main/scala/services/sparql/enrichment/EnrichingRepository.scala
+++ b/src/main/scala/services/sparql/enrichment/EnrichingRepository.scala
@@ -1,6 +1,8 @@
 package se.lu.nateko.cp.meta.services.sparql.enrichment
 
 import scala.language.unsafeNulls
+import scala.util.boundary
+import scala.util.boundary.break
 
 import org.eclipse.rdf4j.common.iteration.CloseableIteration
 import org.eclipse.rdf4j.model.{IRI, Resource, Value, ValueFactory}
@@ -53,18 +55,19 @@ private final class EnrichingRepositoryConnection(
 ) extends RepositoryConnectionWrapper(repository, base) {
 
 	private def needsEnrichment(ql: QueryLanguage, query: String, baseUri: String): Boolean = {
-		val parsed = QueryParserUtil.parseQuery(ql, query, baseUri)
-		var result = false
-		parsed.getTupleExpr.visitChildren(new AbstractQueryModelVisitor[RuntimeException] {
-			override def meet(pattern: StatementPattern): Unit = {
-				val predicate = pattern.getPredicateVar
-				if (
-					!predicate.hasValue || predicate.getValue.isInstanceOf[IRI] &&
-					computedPredicates.contains(predicate.getValue.asInstanceOf[IRI])
-				) result = true
-			}
-		})
-		result
+		boundary {
+			val parsed = QueryParserUtil.parseQuery(ql, query, baseUri)
+			parsed.getTupleExpr.visitChildren(new AbstractQueryModelVisitor[RuntimeException] {
+				override def meet(pattern: StatementPattern): Unit = {
+					val predicate = pattern.getPredicateVar
+					if (
+						!predicate.hasValue || predicate.getValue.isInstanceOf[IRI] &&
+						computedPredicates.contains(predicate.getValue.asInstanceOf[IRI])
+					) break(true)
+				}
+			})
+			false
+		}
 	}
 
 	private def target(ql: QueryLanguage, query: String, baseUri: String): RepositoryConnection = {

--- a/src/main/scala/services/sparql/enrichment/StatementsEnricher.scala
+++ b/src/main/scala/services/sparql/enrichment/StatementsEnricher.scala
@@ -1,0 +1,72 @@
+package se.lu.nateko.cp.meta.services.sparql.enrichment
+
+import scala.language.unsafeNulls
+
+import org.eclipse.rdf4j.common.iteration.{CloseableIteration, EmptyIteration, SingletonIteration, UnionIteration}
+import org.eclipse.rdf4j.model.{IRI, Resource, Statement, Value, ValueFactory}
+import org.eclipse.rdf4j.repository.sparql.federation.CollectionIteration
+import org.eclipse.rdf4j.sail.SailException
+import se.lu.nateko.cp.meta.core.data.References
+import se.lu.nateko.cp.meta.services.citation.CitationProvider
+import se.lu.nateko.cp.meta.utils.rdf4j.{createStringLiteral, toRdf}
+
+import java.util.Arrays
+import scala.collection.immutable.SeqMap
+
+private[enrichment] class StatementsEnricher(val citer: CitationProvider) {
+	import StatementsEnricher.StatIter
+	import citer.metaVocab
+	private given factory: ValueFactory = metaVocab.factory
+
+	private def empty: StatIter = new EmptyIteration
+
+	def enrich(base: StatIter, subj: Resource, pred: IRI, obj: Value): StatIter = {
+		try {
+			val extras = getExtras(subj, pred, obj)
+			if(!extras.hasNext) base else UnionIteration(base, extras)
+		} catch {
+			case err => throw SailException(err.getMessage, err)
+		}
+	}
+
+	private def getExtras(subj: Resource, pred: IRI, obj: Value): StatIter = {
+		if(subj == null || obj != null) empty //lookup by computed values is not possible
+		else{
+			val citationFactories = citationPredValueFactories(subj)
+			if(pred != null && !citationFactories.contains(pred)) empty
+			else if(pred == null) {
+				val extras = citationFactories.iterator.flatMap{
+					(pred, thunk) => thunk().map(v => factory.createStatement(subj, pred, v))
+				}
+				new CollectionIteration(Arrays.asList(extras.toArray*))
+			}
+			else (
+				for(thunk <- citationFactories.get(pred); v <- thunk()) yield
+					new SingletonIteration(factory.createStatement(subj, pred, v))
+			).getOrElse(empty)
+		}
+	}
+
+	private def citationPredValueFactories(subj: Resource): Map[IRI, () => Option[Value]] = {
+		var refsCache: Option[Option[References]] = None
+		SeqMap(
+			metaVocab.hasBiblioInfo -> (() => {
+				import spray.json.*
+				import se.lu.nateko.cp.meta.core.data.JsonSupport.{given RootJsonFormat[References]}
+				val refs = citer.getReferences(subj)
+				refsCache = Some(refs)
+				refs.map(js => factory.createStringLiteral(js.toJson.compactPrint))
+			}),
+			metaVocab.hasCitationString -> (
+				() => refsCache.fold(citer.getCitation(subj))(_.flatMap(_.citationString)).map(factory.createStringLiteral)
+			),
+			metaVocab.dcterms.license -> (
+				() => refsCache.fold(citer.getLicence(subj))(_.flatMap(_.licence)).map(_.url.toRdf)
+			)
+		)
+	}
+}
+
+private object StatementsEnricher{
+	type StatIter = CloseableIteration[? <: Statement]
+}

--- a/src/test/scala/test/services/sparql/SparqlRouteTests.scala
+++ b/src/test/scala/test/services/sparql/SparqlRouteTests.scala
@@ -130,6 +130,26 @@ class SparqlRouteTests extends AsyncFunSpec with ScalatestRouteTest:
 				assertCORS()
 				assert(responseAs[String].trim == "dobj,cit")
 
+		it("Citation properties are computed for a valid object") {
+			val objUri = "https://meta.icos-cp.eu/objects/R5U1rVcbEQbdf9l801lvDUSZ"
+			val query = s"""
+				prefix cpmeta: <http://meta.icos-cp.eu/ontologies/cpmeta/>
+
+				select ?citation ?biblio where {
+					VALUES ?dobj { <$objUri> }
+					?dobj cpmeta:hasCitationString ?citation ;
+						cpmeta:hasBiblioInfo ?biblio .
+				}
+				"""
+
+			testRoute(query) {
+				assert(status === StatusCodes.OK)
+				val result = responseAs[String]
+				assert(result.contains("ICOS ATC CO2 Release"))
+				assert(result.contains("citationString"))
+			}
+		}
+
 		it("Broken object is excluded from a 'biblioinfo' query on multiple objects"):
 			val objUri = "https://meta.icos-cp.eu/objects/a31A8q-hCILq74TM9GoIW9Yg"
 			val query = s"""

--- a/src/test/scala/test/services/sparql/regression/TestDb.scala
+++ b/src/test/scala/test/services/sparql/regression/TestDb.scala
@@ -16,7 +16,8 @@ import se.lu.nateko.cp.meta.core.data.EnvriConfigs
 import se.lu.nateko.cp.meta.ingestion.{BnodeStabilizers, Ingestion, RdfXmlFileIngester}
 import se.lu.nateko.cp.meta.instanceserver.Rdf4jInstanceServer
 import se.lu.nateko.cp.meta.services.Rdf4jSparqlRunner
-import se.lu.nateko.cp.meta.services.citation.{CitationClient, CitationStyle}
+import se.lu.nateko.cp.meta.services.citation.{CitationClient, CitationProvider, CitationStyle}
+import se.lu.nateko.cp.meta.services.sparql.enrichment.EnrichingRepository
 import se.lu.nateko.cp.meta.utils.async.executeSequentially
 
 import scala.concurrent.duration.Duration
@@ -42,6 +43,8 @@ private val graphIriToFile = Seq(
 	("http://meta.icos-cp.eu/ontologies/stationentry/" -> "stationEntry.owl") +
 	("http://meta.icos-cp.eu/collections/" -> "collections.rdf") +
 	("http://meta.icos-cp.eu/documents/" -> "icosdocs.rdf")
+
+private val metaConf = se.lu.nateko.cp.meta.ConfigLoader.default
 
 class TestDb {
 	TestRepo.checkout()
@@ -74,10 +77,11 @@ private object TestRepo {
 		val start = System.currentTimeMillis()
 		val repo = SailRepository(MemoryStore())
 		repo.init()
-		ingestTriplestore(repo).map(Done =>
+		ingestTriplestore(repo).map { Done =>
 			log.info(s"TestDb init: ${System.currentTimeMillis() - start} ms")
-			repo
-		)
+			val citer = new CitationProvider(repo, _ => CitationClientDummy, metaConf)
+			EnrichingRepository(repo, citer)
+		}
 	}
 
 	def checkout() = {


### PR DESCRIPTION
This preserves the original behavior of enriching `hasCitationString`, `hasBiblioInfo` and license on the fly, rather than the approach of pre-materializing triples in https://github.com/ICOS-Carbon-Portal/meta/pull/365.
This should preserve original functionality, but removes the possibility of running the SPARQL endpoint directly against Virtuoso.
At a later point, we could split out this logic from `meta` into a smaller service in front of Virtuoso, which would then still allow us to redeploy `meta` without disturbing the SPARQL endpoint.

[StatementsEnricher.scala](https://github.com/ICOS-Carbon-Portal/meta/blob/valter/virtuoso-enriched/src/main/scala/services/sparql/enrichment/StatementsEnricher.scala#L1) is copied verbatim from `master`, with some renames and minor visibility edits.